### PR TITLE
P0.3: config schema for telegram/review/replica sections

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -34,7 +34,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 |----------|--------|-------|-------------|----------|--------|----|
 | P0.1 | `task/P0.1-entrypoints` | T-001..T-013 | claude | codex | pending | — |
 | P0.2 | `task/P0.2-trigger` | T-014..T-018 | codex | claude | pending | — |
-| P0.3 | `task/P0.3-config-schema` | T-019 | codex | claude | pending | — |
+| P0.3 | `task/P0.3-config-schema` | T-019 | codex | claude | in-progress, codex | — |
 | P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | pending | — |
 | P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | pending | — |
 | P1.3 | `task/P1.3-sdk-errors` | T-034..T-040 | codex | claude | pending | — |
@@ -92,7 +92,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-018 — pending
 
 ### P0.3 — Schema config
-- [ ] T-019 — pending
+- [ ] T-019 — in-progress (codex)
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -34,7 +34,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 |----------|--------|-------|-------------|----------|--------|----|
 | P0.1 | `task/P0.1-entrypoints` | T-001..T-013 | claude | codex | pending | — |
 | P0.2 | `task/P0.2-trigger` | T-014..T-018 | codex | claude | pending | — |
-| P0.3 | `task/P0.3-config-schema` | T-019 | codex | claude | in-progress, codex | — |
+| P0.3 | `task/P0.3-config-schema` | T-019 | codex | claude | in-review, PR #1 | #1 |
 | P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | pending | — |
 | P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | pending | — |
 | P1.3 | `task/P1.3-sdk-errors` | T-034..T-040 | codex | claude | pending | — |
@@ -92,7 +92,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-018 — pending
 
 ### P0.3 — Schema config
-- [ ] T-019 — in-progress (codex)
+- [x] T-019 — in-review (PR #1)
 
 ---
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -79,6 +79,24 @@ export const AuthSchema = z.object({
   oauth_auto_refresh: z.boolean().default(true),
 });
 
+export const TelegramConfigSchema = z.object({
+  secret: z.string().min(1),
+  allowed_user_ids: z.array(z.number().int().positive()).default([]),
+  default_priority: z.enum(["LOW", "NORMAL", "HIGH", "URGENT"]).default("NORMAL"),
+  default_agent: z.string().default("telegram-bot"),
+});
+
+export const ReviewConfigSchema = z.object({
+  review_required: z.boolean().default(false),
+  stages: z.array(z.string()).default(["implementer", "spec-reviewer", "code-quality-reviewer"]),
+  max_retries_per_stage: z.number().int().nonnegative().default(2),
+});
+
+export const ReplicaConfigSchema = z.object({
+  expected_replicas: z.array(z.string()).default([]),
+  max_age_minutes: z.number().int().positive().default(90),
+});
+
 export const ClawdeConfigSchema = z.object({
   clawde: ClawdeBaseSchema.default(() => ClawdeBaseSchema.parse({})),
   worker: WorkerSchema.default(() => WorkerSchema.parse({})),
@@ -87,6 +105,9 @@ export const ClawdeConfigSchema = z.object({
   sandbox: SandboxSchema.default(() => SandboxSchema.parse({})),
   memory: MemorySchema.default(() => MemorySchema.parse({})),
   auth: AuthSchema.default(() => AuthSchema.parse({})),
+  telegram: TelegramConfigSchema.optional(),
+  review: ReviewConfigSchema.optional(),
+  replica: ReplicaConfigSchema.optional(),
 });
 
 export type ClawdeConfig = z.infer<typeof ClawdeConfigSchema>;

--- a/tests/unit/config/load.test.ts
+++ b/tests/unit/config/load.test.ts
@@ -47,12 +47,44 @@ max_parallel = 4
     expect(cfg.worker.cli_path).toBe("/usr/local/bin/claude");
   });
 
-  test("config-example completo é válido", () => {
-    const examplePath = join(import.meta.dirname, "../../../deploy/config-example/clawde.toml");
+  test("config/clawde.toml.example é válido", () => {
+    const examplePath = join(import.meta.dirname, "../../../config/clawde.toml.example");
     const cfg = loadConfig({ path: examplePath, env: {} });
     expect(cfg.quota.plan).toBe("max5x");
     expect(cfg.quota.peak_multiplier).toBe(1.7);
     expect(cfg.sandbox.default_level).toBe(1);
+  });
+
+  test("subseções opcionais telegram/review/replica validam tipos", () => {
+    writeFileSync(
+      path,
+      `
+[telegram]
+secret = "hook-secret"
+allowed_user_ids = [42, 1234]
+default_priority = "HIGH"
+default_agent = "telegram-bot"
+
+[review]
+review_required = true
+stages = ["implementer", "spec-reviewer", "code-quality-reviewer"]
+max_retries_per_stage = 3
+
+[replica]
+expected_replicas = ["b2", "local"]
+max_age_minutes = 45
+`,
+    );
+
+    const cfg = loadConfig({ path, env: {} });
+    expect(cfg.telegram?.secret).toBe("hook-secret");
+    expect(cfg.telegram?.allowed_user_ids).toEqual([42, 1234]);
+    expect(cfg.telegram?.default_priority).toBe("HIGH");
+    expect(cfg.review?.review_required).toBe(true);
+    expect(cfg.review?.stages).toEqual(["implementer", "spec-reviewer", "code-quality-reviewer"]);
+    expect(cfg.review?.max_retries_per_stage).toBe(3);
+    expect(cfg.replica?.expected_replicas).toEqual(["b2", "local"]);
+    expect(cfg.replica?.max_age_minutes).toBe(45);
   });
 
   test("valor inválido lança ConfigError com path", () => {


### PR DESCRIPTION
Closes sub-phase P0.3 in EXECUTION_BACKLOG.md.

## Tasks included
- T-019: add TelegramConfigSchema, ReviewConfigSchema, ReplicaConfigSchema to root config schema

## What changed
Added optional , , and  sections to  in , with strict typing and defaults for each subsection. Updated config loading tests to validate  and added explicit type-validation coverage for each optional subsection.

## Acceptance criteria validated
- [x] Root schema accepts optional , , 
- [x]  accepts  without errors
- [x] Schemas validate types of each subsection

## CI
- [x]  clean
- [x] Checked 153 files in 1009ms. No fixes applied. clean
- [ ] bun test v1.3.13 (bf2e2cec)
applied: 1, 2
applied: 1, 2
{
  "applied": [
    1,
    2
  ]
}
applied: 1, 2
applied: 1, 2 passing (local environment has unrelated port-collision failures in integration/e2e suites)
- [ ] Manual smoke (N/A)

## Notes for reviewer
- Implementation follows the snippet in CONSOLIDATED_FIX_PLAN.md §P0.3.
- No behavior changes outside config parsing/validation.

## Cross-wave dependencies
- None

🤖 Implemented by Codex