### PR TITLE
P1.1: pending retry dequeue + run reuse

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -35,7 +35,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P0.1 | `task/P0.1-entrypoints` | T-001..T-013 | claude | codex | merged, PR #2, 2026-04-29 | #2 |
 | P0.2 | `task/P0.2-trigger` | T-014..T-018 | codex | claude | merged, PR #3, 2026-04-29 | #3 |
 | P0.3 | `task/P0.3-config-schema` | T-019 | codex | claude | merged, PR #1, 2026-04-29 | #1 |
-| P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | pending | — |
+| P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | in-progress, codex | — |
 | P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | pending | — |
 | P1.3 | `task/P1.3-sdk-errors` | T-034..T-040 | codex | claude | pending | — |
 | P2.1 | `task/P2.1-workspace-plug` | T-041..T-046 | codex | claude | pending | — |
@@ -99,10 +99,10 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 ## Wave 2 — Operação consistente (P1.1, P1.2, P1.3)
 
 ### P1.1 — findPending considera retries
-- [ ] T-020 — pending
-- [ ] T-021 — pending
-- [ ] T-022 — pending
-- [ ] T-023 — pending
+- [ ] T-020 — in-progress (codex)
+- [ ] T-021 — in-progress (codex)
+- [ ] T-022 — in-progress (codex)
+- [ ] T-023 — in-progress (codex)
 
 ### P1.2 — Quota policy com not_before
 - [ ] T-024 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -35,7 +35,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P0.1 | `task/P0.1-entrypoints` | T-001..T-013 | claude | codex | merged, PR #2, 2026-04-29 | #2 |
 | P0.2 | `task/P0.2-trigger` | T-014..T-018 | codex | claude | merged, PR #3, 2026-04-29 | #3 |
 | P0.3 | `task/P0.3-config-schema` | T-019 | codex | claude | merged, PR #1, 2026-04-29 | #1 |
-| P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | in-progress, codex | — |
+| P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | in-review, PR #4 | #4 |
 | P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | pending | — |
 | P1.3 | `task/P1.3-sdk-errors` | T-034..T-040 | codex | claude | pending | — |
 | P2.1 | `task/P2.1-workspace-plug` | T-041..T-046 | codex | claude | pending | — |
@@ -99,10 +99,10 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 ## Wave 2 — Operação consistente (P1.1, P1.2, P1.3)
 
 ### P1.1 — findPending considera retries
-- [ ] T-020 — in-progress (codex)
-- [ ] T-021 — in-progress (codex)
-- [ ] T-022 — in-progress (codex)
-- [ ] T-023 — in-progress (codex)
+- [x] T-020 — in-review, PR #4
+- [x] T-021 — in-review, PR #4
+- [x] T-022 — in-review, PR #4
+- [x] T-023 — in-review, PR #4
 
 ### P1.2 — Quota policy com not_before
 - [ ] T-024 — pending

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -122,8 +122,13 @@ export class TasksRepo {
     const rows = this.db
       .query<RawTaskRow, [number]>(
         `SELECT t.* FROM tasks t
-         LEFT JOIN task_runs tr ON tr.task_id = t.id
-         WHERE tr.id IS NULL
+         LEFT JOIN task_runs tr_latest
+           ON tr_latest.task_id = t.id
+          AND tr_latest.id = (
+            SELECT MAX(id) FROM task_runs WHERE task_id = t.id
+          )
+         WHERE tr_latest.id IS NULL
+            OR tr_latest.status = 'pending'
          ORDER BY
            CASE t.priority
              WHEN 'URGENT' THEN 0

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -56,6 +56,16 @@ export interface ProcessResult {
   readonly agentResult: AgentRunResult;
 }
 
+class LeaseBusyError extends Error {
+  constructor(
+    readonly taskId: number,
+    readonly taskRunId: number,
+  ) {
+    super(`lease busy for task ${taskId} run ${taskRunId}`);
+    this.name = "LeaseBusyError";
+  }
+}
+
 /**
  * Processa 1 task end-to-end.
  *   - INSERT task_run (pending)
@@ -67,10 +77,19 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
   const log = deps.logger.child({ taskId: task.id });
   log.info("task processing", { agent: task.agent, priority: task.priority });
 
-  const run = deps.runsRepo.insert(task.id, deps.workerId);
+  const latest = deps.runsRepo.findLatestByTaskId(task.id);
+  let run: TaskRun;
+  if (latest === null) {
+    run = deps.runsRepo.insert(task.id, deps.workerId);
+  } else if (latest.status === "pending") {
+    run = latest;
+  } else {
+    throw new LeaseBusyError(task.id, latest.id);
+  }
+
   const acquisition = deps.leaseManager.acquire(run.id);
   if (acquisition === null) {
-    throw new Error(`failed to acquire lease for task_run ${run.id}`);
+    throw new LeaseBusyError(task.id, run.id);
   }
 
   // Memory inject opcional: prepend snippet de observations relevantes.
@@ -159,7 +178,12 @@ export async function processNextPending(deps: RunnerDeps): Promise<ProcessResul
   if (pending.length === 0) return null;
   const task = pending[0];
   if (task === undefined) return null;
-  return processTask(deps, task);
+  try {
+    return await processTask(deps, task);
+  } catch (err) {
+    if (err instanceof LeaseBusyError) return null;
+    throw err;
+  }
 }
 
 async function runAgentWithLedger(

--- a/tests/integration/lease-reconcile.test.ts
+++ b/tests/integration/lease-reconcile.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { EventsRepo } from "@clawde/db/repositories/events";
+import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
-import { LeaseManager, makeReconciler } from "@clawde/worker";
+import { createLogger } from "@clawde/log";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker } from "@clawde/quota";
+import { LeaseManager, makeReconciler, processNextPending } from "@clawde/worker";
 import { type TestDb, makeTestDb } from "../helpers/db.ts";
+import { MockAgentClient, assistantText } from "../mocks/sdk-mock.ts";
 
 describe("worker/lease + reconcile integration", () => {
   let testDb: TestDb;
@@ -120,5 +124,35 @@ describe("worker/lease + reconcile integration", () => {
     const result = reconciler.reconcile("worker-host01");
     expect(result.expired).toHaveLength(0);
     expect(result.reenqueued).toHaveLength(0);
+  });
+
+  test("lease expirado → reconcile → worker pega retry e attempt 2 termina succeeded", async () => {
+    const run = runsRepo.insert(taskId, "w1");
+    runsRepo.acquireLease(run.id, 60);
+    testDb.db.exec(
+      `UPDATE task_runs SET lease_until = datetime('now', '-10 seconds') WHERE id = ${run.id}`,
+    );
+
+    const reconciler = makeReconciler(runsRepo, eventsRepo);
+    const rec = reconciler.reconcile("worker-host01");
+    expect(rec.reenqueued).toHaveLength(1);
+
+    const mockClient = new MockAgentClient();
+    mockClient.enqueueResponse({ messages: [assistantText("retry ok")] });
+    const deps = {
+      tasksRepo,
+      runsRepo,
+      eventsRepo,
+      leaseManager: lease,
+      quotaTracker: new QuotaTracker(new QuotaLedgerRepo(testDb.db), DEFAULT_TRACKER_CONFIG),
+      agentClient: mockClient,
+      logger: createLogger({ component: "lease-reconcile-test" }),
+      workerId: "worker-retry",
+    };
+
+    const processed = await processNextPending(deps);
+    expect(processed).not.toBeNull();
+    expect(processed?.run.attemptN).toBe(2);
+    expect(processed?.run.status).toBe("succeeded");
   });
 });

--- a/tests/integration/worker.test.ts
+++ b/tests/integration/worker.test.ts
@@ -192,4 +192,34 @@ describe("worker/runner end-to-end (com SDK mocked)", () => {
     await processTask(deps, task);
     expect(Date.now() - t0).toBeLessThan(2000);
   });
+
+  test("dois workers paralelos: só um pega lease e attempt_n não duplica", async () => {
+    const task = deps.tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "parallel",
+      agent: "default",
+      sessionId: null,
+      workingDir: null,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+    mockClient.enqueueResponse({ messages: [assistantText("ok")] });
+
+    const deps2: RunnerDeps = { ...deps, workerId: "worker-test-2" };
+    const [r1, r2] = await Promise.all([processNextPending(deps), processNextPending(deps2)]);
+    const processed = [r1, r2].filter((r) => r !== null);
+
+    expect(processed).toHaveLength(1);
+    expect(processed[0]?.task.id).toBe(task.id);
+
+    const runs = testDb.db
+      .query<{ status: string; attempt_n: number }, [number]>(
+        "SELECT status, attempt_n FROM task_runs WHERE task_id = ? ORDER BY attempt_n",
+      )
+      .all(task.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.attempt_n).toBe(1);
+  });
 });

--- a/tests/unit/db/tasks.repo.test.ts
+++ b/tests/unit/db/tasks.repo.test.ts
@@ -93,11 +93,22 @@ describe("repositories/tasks", () => {
     expect(pending.map((t) => t.prompt)).toEqual(["urgent-1", "normal-1", "low-1"]);
   }, 10000);
 
-  test("findPending exclui tasks com task_runs", () => {
-    const t = repo.insert(sampleTask({ prompt: "with-run" }));
+  test("findPending inclui tasks com latest run em pending", () => {
+    const t = repo.insert(sampleTask({ prompt: "with-pending-run" }));
     repo.insert(sampleTask({ prompt: "without-run" }));
     testDb.db.exec(
       `INSERT INTO task_runs (task_id, worker_id, status) VALUES (${t.id}, 'w1', 'pending')`,
+    );
+
+    const pending = repo.findPending();
+    expect(pending.map((p) => p.prompt)).toEqual(["with-pending-run", "without-run"]);
+  });
+
+  test("findPending exclui tasks com latest run não-pending", () => {
+    const t = repo.insert(sampleTask({ prompt: "with-succeeded-run" }));
+    repo.insert(sampleTask({ prompt: "without-run" }));
+    testDb.db.exec(
+      `INSERT INTO task_runs (task_id, worker_id, status) VALUES (${t.id}, 'w1', 'succeeded')`,
     );
 
     const pending = repo.findPending();


### PR DESCRIPTION
Closes sub-phase P1.1 in EXECUTION_BACKLOG.md.

## Tasks included
- T-020: `TasksRepo.findPending` now includes tasks whose latest run is `pending`
- T-021: `processTask` reuses latest pending run instead of creating a new attempt
- T-022: integration coverage for lease-expired retry path ending as succeeded on attempt 2
- T-023: parallel worker coverage ensuring only one lease winner and no duplicated attempt

## What changed
Updated dequeue SQL to select tasks with no runs or latest run in `pending`, preserving priority ordering. Worker processing now checks latest run status and reuses pending runs; when lease is already busy, it returns null via `processNextPending` rather than creating duplicate attempts. Added/updated unit and integration tests for retry pickup and parallel contention behavior.

## Acceptance criteria validated
- [x] T-020 latest-run aware pending query implemented
- [x] T-021 pending run reuse implemented in worker runner
- [x] T-022 reconcile retry scenario covered and passes (attempt 2 succeeds)
- [x] T-023 parallel workers contention covered; only one attempt created

## CI
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (existing warnings only: console.warn in bootstrap tests)
- [x] targeted tests for tasks/lease/worker pass
- [ ] full `bun test` still has 1 pre-existing flaky failure: `repositories/task-runs > findExpiredLeases ...`

## Notes for reviewer
- `processTask` now uses a `LeaseBusyError` internal path so `processNextPending` can gracefully return null on race.

## Cross-wave dependencies
- None

🤖 Implemented by Codex
