### PR TITLE
P1.2: quota gate with task_runs.not_before defer

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -36,7 +36,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P0.2 | `task/P0.2-trigger` | T-014..T-018 | codex | claude | merged, PR #3, 2026-04-29 | #3 |
 | P0.3 | `task/P0.3-config-schema` | T-019 | codex | claude | merged, PR #1, 2026-04-29 | #1 |
 | P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | merged, PR #4, 2026-04-29 | #4 |
-| P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | in-progress, codex | — |
+| P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | in-review, PR #5 | #5 |
 | P1.3 | `task/P1.3-sdk-errors` | T-034..T-040 | codex | claude | pending | — |
 | P2.1 | `task/P2.1-workspace-plug` | T-041..T-046 | codex | claude | pending | — |
 | P2.2 | `task/P2.2-sandbox-tools` | T-047..T-053 | codex | claude | pending | — |
@@ -105,16 +105,16 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-023 — merged, PR #4, 2026-04-29
 
 ### P1.2 — Quota policy com not_before
-- [ ] T-024 — in-progress (codex)
-- [ ] T-025 — in-progress (codex)
-- [ ] T-026 — in-progress (codex)
-- [ ] T-027 — in-progress (codex)
-- [ ] T-028 — in-progress (codex)
-- [ ] T-029 — in-progress (codex)
-- [ ] T-030 — in-progress (codex)
-- [ ] T-031 — in-progress (codex)
-- [ ] T-032 — in-progress (codex)
-- [ ] T-033 — in-progress (codex)
+- [x] T-024 — in-review, PR #5
+- [x] T-025 — in-review, PR #5
+- [x] T-026 — in-review, PR #5
+- [x] T-027 — in-review, PR #5
+- [x] T-028 — in-review, PR #5
+- [x] T-029 — in-review, PR #5
+- [x] T-030 — in-review, PR #5
+- [x] T-031 — in-review, PR #5
+- [x] T-032 — in-review, PR #5
+- [x] T-033 — in-review, PR #5
 
 ### P1.3 — SDK error tipados
 - [ ] T-034 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -36,7 +36,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P0.2 | `task/P0.2-trigger` | T-014..T-018 | codex | claude | merged, PR #3, 2026-04-29 | #3 |
 | P0.3 | `task/P0.3-config-schema` | T-019 | codex | claude | merged, PR #1, 2026-04-29 | #1 |
 | P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | merged, PR #4, 2026-04-29 | #4 |
-| P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | pending | — |
+| P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | in-progress, codex | — |
 | P1.3 | `task/P1.3-sdk-errors` | T-034..T-040 | codex | claude | pending | — |
 | P2.1 | `task/P2.1-workspace-plug` | T-041..T-046 | codex | claude | pending | — |
 | P2.2 | `task/P2.2-sandbox-tools` | T-047..T-053 | codex | claude | pending | — |
@@ -105,16 +105,16 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-023 — merged, PR #4, 2026-04-29
 
 ### P1.2 — Quota policy com not_before
-- [ ] T-024 — pending
-- [ ] T-025 — pending
-- [ ] T-026 — pending
-- [ ] T-027 — pending
-- [ ] T-028 — pending
-- [ ] T-029 — pending
-- [ ] T-030 — pending
-- [ ] T-031 — pending
-- [ ] T-032 — pending
-- [ ] T-033 — pending
+- [ ] T-024 — in-progress (codex)
+- [ ] T-025 — in-progress (codex)
+- [ ] T-026 — in-progress (codex)
+- [ ] T-027 — in-progress (codex)
+- [ ] T-028 — in-progress (codex)
+- [ ] T-029 — in-progress (codex)
+- [ ] T-030 — in-progress (codex)
+- [ ] T-031 — in-progress (codex)
+- [ ] T-032 — in-progress (codex)
+- [ ] T-033 — in-progress (codex)
 
 ### P1.3 — SDK error tipados
 - [ ] T-034 — pending

--- a/src/db/migrations/003_task_runs_not_before.down.sql
+++ b/src/db/migrations/003_task_runs_not_before.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_task_runs_pending_not_before;
+
+ALTER TABLE task_runs
+DROP COLUMN not_before;

--- a/src/db/migrations/003_task_runs_not_before.up.sql
+++ b/src/db/migrations/003_task_runs_not_before.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE task_runs
+ADD COLUMN not_before TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_task_runs_pending_not_before
+ON task_runs(status, not_before)
+WHERE status = 'pending';

--- a/src/db/repositories/task-runs.ts
+++ b/src/db/repositories/task-runs.ts
@@ -13,6 +13,7 @@ interface RawTaskRunRow {
   attempt_n: number;
   worker_id: string;
   status: TaskRunStatus;
+  not_before: string | null;
   lease_until: string | null;
   started_at: string | null;
   finished_at: string | null;
@@ -28,6 +29,7 @@ function rowToTaskRun(r: RawTaskRunRow): TaskRun {
     attemptN: r.attempt_n,
     workerId: r.worker_id,
     status: r.status,
+    notBefore: r.not_before,
     leaseUntil: r.lease_until,
     startedAt: r.started_at,
     finishedAt: r.finished_at,
@@ -43,7 +45,7 @@ export class TaskRunsRepo {
   /**
    * Insere novo task_run em status=pending. attempt_n auto-incrementa por task_id.
    */
-  insert(taskId: number, workerId: string): TaskRun {
+  insert(taskId: number, workerId: string, options?: { notBefore?: string | null }): TaskRun {
     const nextAttempt =
       this.db
         .query<{ n: number }, [number]>(
@@ -52,11 +54,11 @@ export class TaskRunsRepo {
         .get(taskId)?.n ?? 1;
 
     const row = this.db
-      .query<RawTaskRunRow, [number, number, string]>(
-        `INSERT INTO task_runs (task_id, attempt_n, worker_id, status)
-         VALUES (?, ?, ?, 'pending') RETURNING *`,
+      .query<RawTaskRunRow, [number, number, string, string | null]>(
+        `INSERT INTO task_runs (task_id, attempt_n, worker_id, status, not_before)
+         VALUES (?, ?, ?, 'pending', ?) RETURNING *`,
       )
-      .get(taskId, nextAttempt, workerId);
+      .get(taskId, nextAttempt, workerId, options?.notBefore ?? null);
     if (row === null) {
       throw new Error("INSERT...RETURNING returned null");
     }
@@ -110,6 +112,15 @@ export class TaskRunsRepo {
       [`+${leaseSeconds} seconds`, id],
     );
     return result.changes > 0;
+  }
+
+  setNotBefore(id: number, isoTimestamp: string | null): TaskRun {
+    this.db.run("UPDATE task_runs SET not_before = ? WHERE id = ?", [isoTimestamp, id]);
+    const after = this.findById(id);
+    if (after === null) {
+      throw new Error(`task_run ${id} disappeared after setNotBefore`);
+    }
+    return after;
   }
 
   /**

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -128,7 +128,13 @@ export class TasksRepo {
             SELECT MAX(id) FROM task_runs WHERE task_id = t.id
           )
          WHERE tr_latest.id IS NULL
-            OR tr_latest.status = 'pending'
+            OR (
+                 tr_latest.status = 'pending'
+                 AND (
+                   tr_latest.not_before IS NULL
+                   OR tr_latest.not_before <= datetime('now')
+                 )
+               )
          ORDER BY
            CASE t.priority
              WHEN 'URGENT' THEN 0

--- a/src/domain/event.ts
+++ b/src/domain/event.ts
@@ -10,6 +10,7 @@ export const EVENT_KIND_VALUES = [
   "auth_fail",
   "rate_limit_hit",
   "dedup_skip",
+  "task_deferred",
   // worker lifecycle
   "task_start",
   "task_finish",

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -48,6 +48,7 @@ export interface TaskRun {
   readonly attemptN: number;
   readonly workerId: string;
   readonly status: TaskRunStatus;
+  readonly notBefore: string | null;
   readonly leaseUntil: string | null;
   readonly startedAt: string | null;
   readonly finishedAt: string | null;

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -8,7 +8,7 @@ import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, setMinLevel } from "@clawde/log";
-import { QuotaTracker } from "@clawde/quota";
+import { QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
 import { RealAgentClient } from "@clawde/sdk";
 import { LeaseManager, makeReconciler, processNextPending } from "./index.ts";
 
@@ -29,6 +29,7 @@ export async function bootstrap(): Promise<void> {
     const runsRepo = new TaskRunsRepo(db);
     const eventsRepo = new EventsRepo(db);
     const quotaTracker = new QuotaTracker(new QuotaLedgerRepo(db));
+    const quotaPolicy = makeQuotaPolicy();
     const leaseManager = new LeaseManager(runsRepo, eventsRepo, {
       leaseSeconds: config.worker.lease_seconds,
       heartbeatSeconds: config.worker.heartbeat_seconds,
@@ -52,6 +53,7 @@ export async function bootstrap(): Promise<void> {
         eventsRepo,
         leaseManager,
         quotaTracker,
+        quotaPolicy,
         agentClient,
         logger,
         workerId,

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -16,6 +16,7 @@ import type { EventsRepo } from "@clawde/db/repositories/events";
 import type { MemoryRepo } from "@clawde/db/repositories/memory";
 import type { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import type { TasksRepo } from "@clawde/db/repositories/tasks";
+import type { QuotaPolicy } from "@clawde/domain/quota";
 import type { Task, TaskRun } from "@clawde/domain/task";
 import type { Logger } from "@clawde/log";
 import type { MemoryAwareConfig, buildMemoryContext as buildMemoryContextFn } from "@clawde/memory";
@@ -41,6 +42,7 @@ export interface RunnerDeps {
   readonly eventsRepo: EventsRepo;
   readonly leaseManager: LeaseManager;
   readonly quotaTracker: QuotaTracker;
+  readonly quotaPolicy: QuotaPolicy;
   readonly agentClient: AgentClient;
   readonly logger: Logger;
   readonly workerId: string;
@@ -77,6 +79,9 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
   const log = deps.logger.child({ taskId: task.id });
   log.info("task processing", { agent: task.agent, priority: task.priority });
 
+  const quotaWindow = deps.quotaTracker.currentWindow();
+  const quotaDecision = deps.quotaPolicy.canAccept(quotaWindow, task.priority);
+
   const latest = deps.runsRepo.findLatestByTaskId(task.id);
   let run: TaskRun;
   if (latest === null) {
@@ -85,6 +90,45 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
     run = latest;
   } else {
     throw new LeaseBusyError(task.id, latest.id);
+  }
+
+  if (!quotaDecision.accept) {
+    if (quotaDecision.deferUntil !== null) {
+      const previousNotBefore = run.notBefore;
+      run = deps.runsRepo.setNotBefore(run.id, quotaDecision.deferUntil);
+      if (previousNotBefore !== quotaDecision.deferUntil) {
+        deps.eventsRepo.insert({
+          taskRunId: run.id,
+          sessionId: task.sessionId,
+          traceId: null,
+          spanId: null,
+          kind: "task_deferred",
+          payload: {
+            task_id: task.id,
+            priority: task.priority,
+            state: quotaWindow.state,
+            defer_until: quotaDecision.deferUntil,
+            reason: quotaDecision.reason,
+          },
+        });
+      }
+    }
+
+    log.info("task deferred by quota policy", {
+      state: quotaWindow.state,
+      defer_until: quotaDecision.deferUntil,
+    });
+    return {
+      task,
+      run,
+      agentResult: {
+        stopReason: "completed",
+        msgsConsumed: 0,
+        totalTurns: 0,
+        finalText: "",
+        error: null,
+      },
+    };
   }
 
   const acquisition = deps.leaseManager.acquire(run.id);

--- a/tests/e2e/lifecycle.test.ts
+++ b/tests/e2e/lifecycle.test.ts
@@ -18,7 +18,7 @@ import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, resetLogSink, setLogSink } from "@clawde/log";
-import { DEFAULT_TRACKER_CONFIG, QuotaTracker } from "@clawde/quota";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
 import { type ReceiverHandle, TokenBucketRateLimiter, createReceiver } from "@clawde/receiver";
 import { NoopWorkerTrigger } from "@clawde/receiver";
 import { makeEnqueueHandler } from "@clawde/receiver/routes/enqueue";
@@ -102,6 +102,7 @@ function startE2E(): E2ESetup {
     eventsRepo,
     leaseManager: lease,
     quotaTracker: tracker,
+    quotaPolicy: makeQuotaPolicy(),
     agentClient: mockClient,
     logger: logger.child({ component: "e2e-worker" }),
     workerId: "worker-e2e",

--- a/tests/integration/e2e-lifecycle.test.ts
+++ b/tests/integration/e2e-lifecycle.test.ts
@@ -19,7 +19,7 @@ import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, resetLogSink, setLogSink } from "@clawde/log";
-import { DEFAULT_TRACKER_CONFIG, QuotaTracker } from "@clawde/quota";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
 import {
   NoopWorkerTrigger,
   type ReceiverHandle,
@@ -83,6 +83,7 @@ async function setup(): Promise<E2E> {
     eventsRepo,
     leaseManager: lease,
     quotaTracker: tracker,
+    quotaPolicy: makeQuotaPolicy(),
     agentClient: mockClient,
     logger,
     workerId: "e2e-worker",

--- a/tests/integration/lease-reconcile.test.ts
+++ b/tests/integration/lease-reconcile.test.ts
@@ -4,7 +4,7 @@ import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger } from "@clawde/log";
-import { DEFAULT_TRACKER_CONFIG, QuotaTracker } from "@clawde/quota";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
 import { LeaseManager, makeReconciler, processNextPending } from "@clawde/worker";
 import { type TestDb, makeTestDb } from "../helpers/db.ts";
 import { MockAgentClient, assistantText } from "../mocks/sdk-mock.ts";
@@ -145,6 +145,7 @@ describe("worker/lease + reconcile integration", () => {
       eventsRepo,
       leaseManager: lease,
       quotaTracker: new QuotaTracker(new QuotaLedgerRepo(testDb.db), DEFAULT_TRACKER_CONFIG),
+      quotaPolicy: makeQuotaPolicy(),
       agentClient: mockClient,
       logger: createLogger({ component: "lease-reconcile-test" }),
       workerId: "worker-retry",

--- a/tests/integration/quota-defer.test.ts
+++ b/tests/integration/quota-defer.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EventsRepo } from "@clawde/db/repositories/events";
+import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
+import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
+import { TasksRepo } from "@clawde/db/repositories/tasks";
+import { createLogger, resetLogSink, setLogSink } from "@clawde/log";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
+import { LeaseManager, type RunnerDeps, processNextPending } from "@clawde/worker";
+import { type TestDb, makeTestDb } from "../helpers/db.ts";
+import { MockAgentClient, assistantText } from "../mocks/sdk-mock.ts";
+
+describe("worker quota defer with not_before", () => {
+  let testDb: TestDb;
+  let deps: RunnerDeps;
+  let tasksRepo: TasksRepo;
+  let runsRepo: TaskRunsRepo;
+  let eventsRepo: EventsRepo;
+  let quotaTracker: QuotaTracker;
+  let quotaRepo: QuotaLedgerRepo;
+  let mockClient: MockAgentClient;
+
+  beforeEach(() => {
+    testDb = makeTestDb();
+    setLogSink(() => {});
+    tasksRepo = new TasksRepo(testDb.db);
+    runsRepo = new TaskRunsRepo(testDb.db);
+    eventsRepo = new EventsRepo(testDb.db);
+    quotaRepo = new QuotaLedgerRepo(testDb.db);
+    quotaTracker = new QuotaTracker(quotaRepo, DEFAULT_TRACKER_CONFIG);
+    mockClient = new MockAgentClient();
+
+    deps = {
+      tasksRepo,
+      runsRepo,
+      eventsRepo,
+      leaseManager: new LeaseManager(runsRepo, eventsRepo, {
+        leaseSeconds: 60,
+        heartbeatSeconds: 999,
+      }),
+      quotaTracker,
+      quotaPolicy: makeQuotaPolicy(),
+      agentClient: mockClient,
+      logger: createLogger({ component: "quota-defer-test" }),
+      workerId: "worker-quota",
+    };
+  });
+
+  afterEach(() => {
+    testDb.cleanup();
+    resetLogSink();
+  });
+
+  test("esgotado não consome ledger, registra task_deferred e mantém task pending", async () => {
+    // Força janela esgotada (capacity max5x = 250).
+    const ws = quotaRepo.currentWindowStart();
+    quotaRepo.insert({
+      msgsConsumed: 1000,
+      windowStart: ws,
+      plan: "max5x",
+      peakMultiplier: 1.0,
+      taskRunId: null,
+    });
+    expect(quotaTracker.currentWindow().state).toBe("esgotado");
+
+    const t = tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "should defer",
+      agent: "default",
+      sessionId: null,
+      workingDir: null,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+    mockClient.enqueueResponse({ messages: [assistantText("should not run")] });
+
+    const before = quotaTracker.currentWindow().msgsConsumed;
+    const result = await processNextPending(deps);
+    const after = quotaTracker.currentWindow().msgsConsumed;
+
+    expect(result).not.toBeNull();
+    expect(result?.run.status).toBe("pending");
+    expect(result?.run.notBefore).not.toBeNull();
+    expect(before).toBe(after);
+
+    const deferredEvents = eventsRepo.queryByKind("task_deferred");
+    expect(deferredEvents.length).toBe(1);
+    expect(deferredEvents[0]?.payload.task_id).toBe(t.id);
+  });
+
+  test("defer repetido não gera spam: evento emitido uma vez", async () => {
+    const ws = quotaRepo.currentWindowStart();
+    quotaRepo.insert({
+      msgsConsumed: 1000,
+      windowStart: ws,
+      plan: "max5x",
+      peakMultiplier: 1.0,
+      taskRunId: null,
+    });
+    tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "defer once",
+      agent: "default",
+      sessionId: null,
+      workingDir: null,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+
+    await processNextPending(deps);
+    await processNextPending(deps);
+    await processNextPending(deps);
+
+    expect(eventsRepo.queryByKind("task_deferred").length).toBe(1);
+  });
+});

--- a/tests/integration/worker-wiring.test.ts
+++ b/tests/integration/worker-wiring.test.ts
@@ -18,7 +18,7 @@ import {
   type MemoryContextResult,
   type buildMemoryContext,
 } from "@clawde/memory";
-import { DEFAULT_TRACKER_CONFIG, QuotaTracker } from "@clawde/quota";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
 import { runReviewPipeline } from "@clawde/review";
 import { LeaseManager, type RunnerDeps, processTask } from "@clawde/worker";
 import { type TestDb, makeTestDb } from "../helpers/db.ts";
@@ -40,6 +40,7 @@ function baseDeps(testDb: TestDb, mockClient: MockAgentClient): RunnerDeps {
     eventsRepo,
     leaseManager: lease,
     quotaTracker: tracker,
+    quotaPolicy: makeQuotaPolicy(),
     agentClient: mockClient,
     logger: createLogger({ component: "test-wire" }),
     workerId: "worker-test",

--- a/tests/integration/worker.test.ts
+++ b/tests/integration/worker.test.ts
@@ -4,7 +4,7 @@ import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, resetLogSink, setLogSink } from "@clawde/log";
-import { DEFAULT_TRACKER_CONFIG, QuotaTracker } from "@clawde/quota";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
 import { LeaseManager, type RunnerDeps, processNextPending, processTask } from "@clawde/worker";
 import { type TestDb, makeTestDb } from "../helpers/db.ts";
 import { MockAgentClient, assistantText } from "../mocks/sdk-mock.ts";
@@ -35,6 +35,7 @@ describe("worker/runner end-to-end (com SDK mocked)", () => {
       eventsRepo,
       leaseManager: lease,
       quotaTracker: tracker,
+      quotaPolicy: makeQuotaPolicy(),
       agentClient: mockClient,
       logger: createLogger({ component: "test-worker" }),
       workerId: "worker-test",

--- a/tests/unit/db/task-runs.repo.test.ts
+++ b/tests/unit/db/task-runs.repo.test.ts
@@ -34,7 +34,15 @@ describe("repositories/task-runs", () => {
     expect(run.status).toBe("pending");
     expect(run.attemptN).toBe(1);
     expect(run.workerId).toBe("worker-a");
+    expect(run.notBefore).toBeNull();
     expect(run.leaseUntil).toBeNull();
+  });
+
+  test("insert aceita notBefore opcional", () => {
+    const run = runsRepo.insert(taskId, "worker-a", {
+      notBefore: "2026-04-29 15:00:00",
+    });
+    expect(run.notBefore).toBe("2026-04-29 15:00:00");
   });
 
   test("insert subsequente para mesmo task incrementa attempt_n", () => {
@@ -143,6 +151,12 @@ describe("repositories/task-runs", () => {
     runsRepo.insert(taskId, "w1"); // attempt 1
     const second = runsRepo.insert(taskId, "w2"); // attempt 2
     expect(runsRepo.findLatestByTaskId(taskId)?.id).toBe(second.id);
+  });
+
+  test("setNotBefore atualiza coluna no run pendente", () => {
+    const run = runsRepo.insert(taskId, "w1");
+    const updated = runsRepo.setNotBefore(run.id, "2026-04-29 16:00:00");
+    expect(updated.notBefore).toBe("2026-04-29 16:00:00");
   });
 
   test("UNIQUE (task_id, attempt_n) protegido pelo schema", () => {

--- a/tests/unit/db/tasks.repo.test.ts
+++ b/tests/unit/db/tasks.repo.test.ts
@@ -115,6 +115,22 @@ describe("repositories/tasks", () => {
     expect(pending.map((p) => p.prompt)).toEqual(["without-run"]);
   });
 
+  test("findPending exclui pending com not_before no futuro", () => {
+    const tFuture = repo.insert(sampleTask({ prompt: "future" }));
+    const tReady = repo.insert(sampleTask({ prompt: "ready" }));
+    testDb.db.exec(
+      `INSERT INTO task_runs (task_id, worker_id, status, not_before)
+       VALUES (${tFuture.id}, 'w1', 'pending', datetime('now', '+1 hour'))`,
+    );
+    testDb.db.exec(
+      `INSERT INTO task_runs (task_id, worker_id, status, not_before)
+       VALUES (${tReady.id}, 'w1', 'pending', datetime('now', '-1 hour'))`,
+    );
+
+    const pending = repo.findPending();
+    expect(pending.map((p) => p.prompt)).toEqual(["ready"]);
+  });
+
   test("insert com priority URGENT é aceito", () => {
     const t = repo.insert(sampleTask({ priority: "URGENT" }));
     expect(t.priority).toBe("URGENT");

--- a/tests/unit/quota/policy.test.ts
+++ b/tests/unit/quota/policy.test.ts
@@ -88,6 +88,41 @@ describe("quota/policy canAccept", () => {
     expect(decision.accept).toBe(true);
     expect(decision.reason).toContain("URGENT bypass");
   });
+
+  test("matriz completa 5 estados x 4 prioridades", () => {
+    const cases: Array<[QuotaState, "LOW" | "NORMAL" | "HIGH" | "URGENT", boolean]> = [
+      ["normal", "LOW", true],
+      ["normal", "NORMAL", true],
+      ["normal", "HIGH", true],
+      ["normal", "URGENT", true],
+      ["aviso", "LOW", false],
+      ["aviso", "NORMAL", true],
+      ["aviso", "HIGH", true],
+      ["aviso", "URGENT", true],
+      ["restrito", "LOW", false],
+      ["restrito", "NORMAL", false],
+      ["restrito", "HIGH", true],
+      ["restrito", "URGENT", true],
+      ["critico", "LOW", false],
+      ["critico", "NORMAL", false],
+      ["critico", "HIGH", false],
+      ["critico", "URGENT", true],
+      ["esgotado", "LOW", false],
+      ["esgotado", "NORMAL", false],
+      ["esgotado", "HIGH", false],
+      ["esgotado", "URGENT", false],
+    ];
+
+    for (const [state, priority, accepted] of cases) {
+      const decision = policy.canAccept(window(state), priority);
+      expect(decision.accept).toBe(accepted);
+      if (accepted) {
+        expect(decision.deferUntil).toBeNull();
+      } else {
+        expect(decision.deferUntil).toBe(window(state).resetsAt);
+      }
+    }
+  });
 });
 
 describe("quota/peak-hours checkPeakHours", () => {


### PR DESCRIPTION
Closes sub-phase P1.2 in EXECUTION_BACKLOG.md.

## Tasks included
- T-024: migration 003 adds `task_runs.not_before` + partial pending index
- T-025: domain `TaskRun` now includes `notBefore`
- T-026: `TaskRunsRepo.insert` accepts optional `notBefore`; added `setNotBefore`
- T-027: `TasksRepo.findPending` now filters by `(not_before IS NULL OR not_before <= datetime('now'))`
- T-028: `RunnerDeps` now includes `quotaPolicy`; worker bootstrap wires `makeQuotaPolicy()`
- T-029/T-030: quota gate before lease acquire; defer path writes `not_before` and creates/reuses pending run
- T-031: expanded quota matrix test (5 states x 4 priorities)
- T-032/T-033: integration tests for defer behavior and anti-spam event emission

## What changed
Implemented quota defer orchestration using `task_runs.not_before` as scheduler gate. Worker now evaluates `quotaPolicy.canAccept` before attempting lease acquisition; when denied, task run remains pending with `not_before` set to `deferUntil` and emits `task_deferred` once per defer timestamp. `findPending` respects `not_before` to avoid repeated wakeups and event spam.

## Acceptance criteria validated
- [x] migration + domain + repo updates for `not_before`
- [x] pending query respects `not_before`
- [x] worker receives `quotaPolicy` and applies pre-lease gate
- [x] defer path creates/reuses pending run with `not_before`
- [x] matrix and integration defer tests added/passing

## CI
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (existing warnings only in bootstrap tests)
- [x] targeted tests pass (quota/task-runs/tasks/worker/defer)
- [ ] full `bun test`: 578/579 pass, 1 known flaky pre-existing (`repositories/task-runs > findExpiredLeases ...`)

## Notes for reviewer
- `processTask` now returns a synthetic no-op `AgentRunResult` when deferred (`msgsConsumed=0`) while keeping run status pending.
- Added event kind `task_deferred` for observability.

## Cross-wave dependencies
- Unblocks P0.1 followup around T-008 quota-gate integration.

🤖 Implemented by Codex
