### PR TITLE
P2.1: workspace ephemeral plug in worker + reconcile cleanup

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -38,7 +38,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | merged, PR #4, 2026-04-29 | #4 |
 | P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | merged, PR #5, 2026-04-29 | #5 |
 | P1.3 | `task/P1.3-sdk-errors` | T-034..T-040 | codex | claude | merged, PR #6, 2026-04-29 | #6 |
-| P2.1 | `task/P2.1-workspace-plug` | T-041..T-046 | codex | claude | pending | — |
+| P2.1 | `task/P2.1-workspace-plug` | T-041..T-046 | codex | claude | in-progress, codex | — |
 | P2.2 | `task/P2.2-sandbox-tools` | T-047..T-053 | codex | claude | pending | — |
 | P2.3 | `task/P2.3-external-input` | T-054..T-057 | claude | codex | pending | — |
 | P2.4 | `task/P2.4-review-fresh` | T-058..T-062 | claude | codex | pending | — |
@@ -130,12 +130,12 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 ## Wave 3 — Segurança core (P2.1 → P2.5)
 
 ### P2.1 — Workspace ephemeral plug
-- [ ] T-041 — pending
-- [ ] T-042 — pending
-- [ ] T-043 — pending
-- [ ] T-044 — pending
-- [ ] T-045 — pending
-- [ ] T-046 — pending
+- [ ] T-041 — in-progress, codex
+- [ ] T-042 — in-progress, codex
+- [ ] T-043 — in-progress, codex
+- [ ] T-044 — in-progress, codex
+- [ ] T-045 — in-progress, codex
+- [ ] T-046 — in-progress, codex
 
 ### P2.2 — Sandbox em tools/hooks
 - [ ] T-047 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -38,7 +38,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P1.1 | `task/P1.1-dequeue-retry` | T-020..T-023 | codex | claude | merged, PR #4, 2026-04-29 | #4 |
 | P1.2 | `task/P1.2-quota-not-before` | T-024..T-033 | codex | claude | merged, PR #5, 2026-04-29 | #5 |
 | P1.3 | `task/P1.3-sdk-errors` | T-034..T-040 | codex | claude | merged, PR #6, 2026-04-29 | #6 |
-| P2.1 | `task/P2.1-workspace-plug` | T-041..T-046 | codex | claude | in-progress, codex | — |
+| P2.1 | `task/P2.1-workspace-plug` | T-041..T-046 | codex | claude | in-review, PR #7 | #7 |
 | P2.2 | `task/P2.2-sandbox-tools` | T-047..T-053 | codex | claude | pending | — |
 | P2.3 | `task/P2.3-external-input` | T-054..T-057 | claude | codex | pending | — |
 | P2.4 | `task/P2.4-review-fresh` | T-058..T-062 | claude | codex | pending | — |
@@ -130,12 +130,12 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 ## Wave 3 — Segurança core (P2.1 → P2.5)
 
 ### P2.1 — Workspace ephemeral plug
-- [ ] T-041 — in-progress, codex
-- [ ] T-042 — in-progress, codex
-- [ ] T-043 — in-progress, codex
-- [ ] T-044 — in-progress, codex
-- [ ] T-045 — in-progress, codex
-- [ ] T-046 — in-progress, codex
+- [x] T-041 — in-review, PR #7
+- [x] T-042 — in-review, PR #7
+- [x] T-043 — in-review, PR #7
+- [x] T-044 — in-review, PR #7
+- [x] T-045 — in-review, PR #7
+- [x] T-046 — in-review, PR #7
 
 ### P2.2 — Sandbox em tools/hooks
 - [ ] T-047 — pending

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -15,8 +15,10 @@ export {
   processTask,
 } from "./runner.ts";
 export {
+  cleanupOrphanWorkspaceSync,
   type CreateWorkspaceInput,
   WorkspaceError,
+  shouldUseEphemeralWorkspace,
   createWorkspace,
   listWorktrees,
   removeWorkspace,

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -34,13 +34,17 @@ export async function bootstrap(): Promise<void> {
       leaseSeconds: config.worker.lease_seconds,
       heartbeatSeconds: config.worker.heartbeat_seconds,
     });
-    const reconciler = makeReconciler(runsRepo, eventsRepo);
+    const reconciler = makeReconciler(runsRepo, eventsRepo, {
+      tasksRepo,
+      workspaceTmpRoot: "/tmp",
+    });
     const agentClient = new RealAgentClient();
     const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
     const reconcileResult = reconciler.reconcile(workerId);
     logger.info("startup reconcile", {
       expired_count: reconcileResult.expired.length,
       reenqueued_count: reconcileResult.reenqueued.length,
+      cleaned_orphans: reconcileResult.cleanedOrphans,
     });
     const maxTasks = 50;
     let processed = 0;
@@ -55,6 +59,7 @@ export async function bootstrap(): Promise<void> {
         agentClient,
         logger,
         workerId,
+        workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
       });
       if (result === null) break;
       processed += 1;

--- a/src/worker/reconcile.ts
+++ b/src/worker/reconcile.ts
@@ -5,22 +5,30 @@
 
 import type { EventsRepo } from "@clawde/db/repositories/events";
 import type { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
+import type { TasksRepo } from "@clawde/db/repositories/tasks";
 import type { TaskRun } from "@clawde/domain/task";
+import { cleanupOrphanWorkspaceSync } from "./workspace.ts";
 
 export interface ReconcileResult {
   readonly expired: ReadonlyArray<TaskRun>;
   readonly reenqueued: ReadonlyArray<{ taskId: number; newRunId: number }>;
+  readonly cleanedOrphans: number;
 }
 
 export interface Reconciler {
   reconcile(workerId: string): ReconcileResult;
 }
 
-export function makeReconciler(runsRepo: TaskRunsRepo, eventsRepo: EventsRepo): Reconciler {
+export function makeReconciler(
+  runsRepo: TaskRunsRepo,
+  eventsRepo: EventsRepo,
+  options?: { tasksRepo?: TasksRepo; workspaceTmpRoot?: string },
+): Reconciler {
   return {
     reconcile(workerId: string): ReconcileResult {
       const expired = runsRepo.findExpiredLeases();
       const reenqueued: Array<{ taskId: number; newRunId: number }> = [];
+      let cleanedOrphans = 0;
 
       for (const run of expired) {
         // Marca como abandoned.
@@ -38,9 +46,20 @@ export function makeReconciler(runsRepo: TaskRunsRepo, eventsRepo: EventsRepo): 
         // Re-enfileira via attempt_n+1.
         const newRun = runsRepo.insert(run.taskId, workerId);
         reenqueued.push({ taskId: run.taskId, newRunId: newRun.id });
+
+        const task = options?.tasksRepo?.findById(run.taskId);
+        if (task?.workingDir !== null && task?.workingDir !== undefined) {
+          try {
+            if (cleanupOrphanWorkspaceSync(task.workingDir, run.id, options?.workspaceTmpRoot)) {
+              cleanedOrphans += 1;
+            }
+          } catch {
+            // best-effort cleanup.
+          }
+        }
       }
 
-      return { expired, reenqueued };
+      return { expired, reenqueued, cleanedOrphans };
     },
   };
 }

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -180,137 +180,138 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
     }
   }
 
-  // Memory inject opcional: prepend snippet de observations relevantes.
-  let effectivePrompt = task.prompt;
-  if (deps.memoryInject?.config.enabled) {
-    try {
-      const ctx = await deps.memoryInject.buildContext(
-        deps.memoryInject.memoryRepo,
-        task.prompt,
-        deps.memoryInject.config,
-      );
-      if (ctx.injected) {
-        effectivePrompt = `${ctx.snippet}\n\n${task.prompt}`;
-      }
-    } catch (err) {
-      log.warn("memory inject failed (continuing without)", { error: (err as Error).message });
-    }
-  }
-
-  // Emite invocation_start.
-  deps.eventsRepo.insert({
-    taskRunId: run.id,
-    sessionId: task.sessionId,
-    traceId: null,
-    spanId: null,
-    kind: "claude_invocation_start",
-    payload: { agent: task.agent, prompt_len: effectivePrompt.length },
-  });
-
-  let agentResult: AgentRunResult;
   try {
-    agentResult =
-      deps.review !== undefined
-        ? await runWithReviewPipeline(deps, task, run.id, effectivePrompt, ephemeralWorkspacePath)
-        : await runAgentWithLedger(deps, task, run.id, effectivePrompt, ephemeralWorkspacePath);
-  } catch (err) {
-    if (err instanceof SdkRateLimitError) {
-      deps.quotaTracker.markCurrentWindowExhausted();
-      const exhaustedWindow = deps.quotaTracker.currentWindow();
-      const failed = deps.leaseManager.finish(acquisition, "failed", {
-        error: err.message,
-      });
-      const deferred = deps.runsRepo.insert(task.id, deps.workerId, {
-        notBefore: exhaustedWindow.resetsAt,
-      });
-      deps.eventsRepo.insert({
-        taskRunId: failed.id,
-        sessionId: task.sessionId,
-        traceId: null,
-        spanId: null,
-        kind: "quota_429_observed",
-        payload: {
-          task_id: task.id,
-          failed_run_id: failed.id,
-          deferred_run_id: deferred.id,
-          retry_after_seconds: err.retryAfterSeconds,
-          defer_until: exhaustedWindow.resetsAt,
-        },
+    // Memory inject opcional: prepend snippet de observations relevantes.
+    let effectivePrompt = task.prompt;
+    if (deps.memoryInject?.config.enabled) {
+      try {
+        const ctx = await deps.memoryInject.buildContext(
+          deps.memoryInject.memoryRepo,
+          task.prompt,
+          deps.memoryInject.config,
+        );
+        if (ctx.injected) {
+          effectivePrompt = `${ctx.snippet}\n\n${task.prompt}`;
+        }
+      } catch (err) {
+        log.warn("memory inject failed (continuing without)", { error: (err as Error).message });
+      }
+    }
+
+    // Emite invocation_start.
+    deps.eventsRepo.insert({
+      taskRunId: run.id,
+      sessionId: task.sessionId,
+      traceId: null,
+      spanId: null,
+      kind: "claude_invocation_start",
+      payload: { agent: task.agent, prompt_len: effectivePrompt.length },
+    });
+
+    let agentResult: AgentRunResult;
+    try {
+      agentResult =
+        deps.review !== undefined
+          ? await runWithReviewPipeline(deps, task, run.id, effectivePrompt, ephemeralWorkspacePath)
+          : await runAgentWithLedger(deps, task, run.id, effectivePrompt, ephemeralWorkspacePath);
+    } catch (err) {
+      if (err instanceof SdkRateLimitError) {
+        deps.quotaTracker.markCurrentWindowExhausted();
+        const exhaustedWindow = deps.quotaTracker.currentWindow();
+        const failed = deps.leaseManager.finish(acquisition, "failed", {
+          error: err.message,
+        });
+        const deferred = deps.runsRepo.insert(task.id, deps.workerId, {
+          notBefore: exhaustedWindow.resetsAt,
+        });
+        deps.eventsRepo.insert({
+          taskRunId: failed.id,
+          sessionId: task.sessionId,
+          traceId: null,
+          spanId: null,
+          kind: "quota_429_observed",
+          payload: {
+            task_id: task.id,
+            failed_run_id: failed.id,
+            deferred_run_id: deferred.id,
+            retry_after_seconds: err.retryAfterSeconds,
+            defer_until: exhaustedWindow.resetsAt,
+          },
+        });
+        return {
+          task,
+          run: deferred,
+          agentResult: {
+            stopReason: "error",
+            msgsConsumed: 0,
+            totalTurns: 0,
+            finalText: "",
+            error: err.message,
+          },
+        };
+      }
+
+      log.error("agent invocation crashed", { error: (err as Error).message });
+      const finished = deps.leaseManager.finish(acquisition, "failed", {
+        error: (err as Error).message,
       });
       return {
         task,
-        run: deferred,
+        run: finished,
         agentResult: {
           stopReason: "error",
           msgsConsumed: 0,
           totalTurns: 0,
           finalText: "",
-          error: err.message,
+          error: (err as Error).message,
         },
       };
     }
 
-    log.error("agent invocation crashed", { error: (err as Error).message });
-    const finished = deps.leaseManager.finish(acquisition, "failed", {
-      error: (err as Error).message,
-    });
-    return {
-      task,
-      run: finished,
-      agentResult: {
-        stopReason: "error",
-        msgsConsumed: 0,
-        totalTurns: 0,
-        finalText: "",
-        error: (err as Error).message,
+    // Emite invocation_end.
+    deps.eventsRepo.insert({
+      taskRunId: run.id,
+      sessionId: task.sessionId,
+      traceId: null,
+      spanId: null,
+      kind: "claude_invocation_end",
+      payload: {
+        stop_reason: agentResult.stopReason,
+        msgs_consumed: agentResult.msgsConsumed,
+        total_turns: agentResult.totalTurns,
       },
-    };
-  }
+    });
 
-  // Emite invocation_end.
-  deps.eventsRepo.insert({
-    taskRunId: run.id,
-    sessionId: task.sessionId,
-    traceId: null,
-    spanId: null,
-    kind: "claude_invocation_end",
-    payload: {
-      stop_reason: agentResult.stopReason,
-      msgs_consumed: agentResult.msgsConsumed,
-      total_turns: agentResult.totalTurns,
-    },
-  });
+    const finalStatus = agentResult.error === null ? "succeeded" : "failed";
+    const finished = deps.leaseManager.finish(acquisition, finalStatus, {
+      result: agentResult.finalText.length > 0 ? agentResult.finalText : null,
+      error: agentResult.error,
+      msgsConsumed: agentResult.msgsConsumed,
+    } as { result?: string; error?: string; msgsConsumed?: number });
 
-  const finalStatus = agentResult.error === null ? "succeeded" : "failed";
-  const finished = deps.leaseManager.finish(acquisition, finalStatus, {
-    result: agentResult.finalText.length > 0 ? agentResult.finalText : null,
-    error: agentResult.error,
-    msgsConsumed: agentResult.msgsConsumed,
-  } as { result?: string; error?: string; msgsConsumed?: number });
-
-  log.info("task finished", { status: finalStatus, msgs: agentResult.msgsConsumed });
-
-  if (ephemeralWorkspacePath !== null && task.workingDir !== null) {
-    try {
-      await removeWorkspace(
-        {
+    log.info("task finished", { status: finalStatus, msgs: agentResult.msgsConsumed });
+    return { task, run: finished, agentResult };
+  } finally {
+    if (ephemeralWorkspacePath !== null && task.workingDir !== null) {
+      try {
+        await removeWorkspace(
+          {
+            path: ephemeralWorkspacePath,
+            baseBranch: workspaceConfig.baseBranch,
+            featureBranch: "",
+            taskRunId: run.id,
+            createdAt: "",
+          },
+          task.workingDir,
+        );
+      } catch (err) {
+        log.warn("workspace cleanup failed", {
+          error: (err as Error).message,
           path: ephemeralWorkspacePath,
-          baseBranch: workspaceConfig.baseBranch,
-          featureBranch: "",
-          taskRunId: run.id,
-          createdAt: "",
-        },
-        task.workingDir,
-      );
-    } catch (err) {
-      log.warn("workspace cleanup failed", {
-        error: (err as Error).message,
-        path: ephemeralWorkspacePath,
-      });
+        });
+      }
     }
   }
-
-  return { task, run: finished, agentResult };
 }
 
 /**

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -35,6 +35,12 @@ import {
   SdkRateLimitError,
 } from "@clawde/sdk";
 import type { LeaseManager } from "./lease.ts";
+import {
+  type AgentDefinitionLike,
+  createWorkspace,
+  removeWorkspace,
+  shouldUseEphemeralWorkspace,
+} from "./workspace.ts";
 
 export interface MemoryInjectDeps {
   readonly memoryRepo: MemoryRepo;
@@ -57,6 +63,8 @@ export interface RunnerDeps {
   readonly agentClient: AgentClient;
   readonly logger: Logger;
   readonly workerId: string;
+  readonly workspaceConfig?: { tmpRoot: string; baseBranch: string };
+  readonly resolveAgentDefinition?: (agent: string) => Promise<AgentDefinitionLike | null>;
   /** Overrides para fluxo de auto-refresh em testes. */
   readonly authRefresh?: {
     readonly runSetupToken?: SetupTokenRunner;
@@ -155,6 +163,23 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
     throw new LeaseBusyError(task.id, run.id);
   }
 
+  const workspaceConfig = deps.workspaceConfig ?? { tmpRoot: "/tmp", baseBranch: "main" };
+  let ephemeralWorkspacePath: string | null = null;
+  if (task.workingDir !== null && deps.resolveAgentDefinition !== undefined) {
+    const agentDef = await deps.resolveAgentDefinition(task.agent);
+    if (shouldUseEphemeralWorkspace(task, agentDef)) {
+      const ws = await createWorkspace({
+        taskRunId: run.id,
+        taskId: task.id,
+        slug: task.prompt.slice(0, 40),
+        baseBranch: workspaceConfig.baseBranch,
+        repoRoot: task.workingDir,
+        tmpRoot: workspaceConfig.tmpRoot,
+      });
+      ephemeralWorkspacePath = ws.path;
+    }
+  }
+
   // Memory inject opcional: prepend snippet de observations relevantes.
   let effectivePrompt = task.prompt;
   if (deps.memoryInject?.config.enabled) {
@@ -186,8 +211,8 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
   try {
     agentResult =
       deps.review !== undefined
-        ? await runWithReviewPipeline(deps, task, run.id, effectivePrompt)
-        : await runAgentWithLedger(deps, task, run.id, effectivePrompt);
+        ? await runWithReviewPipeline(deps, task, run.id, effectivePrompt, ephemeralWorkspacePath)
+        : await runAgentWithLedger(deps, task, run.id, effectivePrompt, ephemeralWorkspacePath);
   } catch (err) {
     if (err instanceof SdkRateLimitError) {
       deps.quotaTracker.markCurrentWindowExhausted();
@@ -265,6 +290,26 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
 
   log.info("task finished", { status: finalStatus, msgs: agentResult.msgsConsumed });
 
+  if (ephemeralWorkspacePath !== null && task.workingDir !== null) {
+    try {
+      await removeWorkspace(
+        {
+          path: ephemeralWorkspacePath,
+          baseBranch: workspaceConfig.baseBranch,
+          featureBranch: "",
+          taskRunId: run.id,
+          createdAt: "",
+        },
+        task.workingDir,
+      );
+    } catch (err) {
+      log.warn("workspace cleanup failed", {
+        error: (err as Error).message,
+        path: ephemeralWorkspacePath,
+      });
+    }
+  }
+
   return { task, run: finished, agentResult };
 }
 
@@ -290,6 +335,7 @@ async function runAgentWithLedger(
   task: Task,
   taskRunId: number,
   effectivePrompt: string,
+  workingDirectoryOverride: string | null,
 ): Promise<AgentRunResult> {
   const AUTH_RETRY_TOKEN = { value: "worker-auth-retry", source: "env" as const };
 
@@ -304,7 +350,11 @@ async function runAgentWithLedger(
     prompt: effectivePrompt,
   };
   if (task.sessionId !== null) streamOpts.sessionId = task.sessionId;
-  if (task.workingDir !== null) streamOpts.workingDirectory = task.workingDir;
+  if (workingDirectoryOverride !== null) {
+    streamOpts.workingDirectory = workingDirectoryOverride;
+  } else if (task.workingDir !== null) {
+    streamOpts.workingDirectory = task.workingDir;
+  }
 
   const runStreamOnce = async (): Promise<void> => {
     for await (const msg of deps.agentClient.stream(streamOpts)) {
@@ -371,6 +421,7 @@ async function runWithReviewPipeline(
   task: Task,
   taskRunId: number,
   effectivePrompt: string,
+  workingDirectoryOverride: string | null,
 ): Promise<AgentRunResult> {
   if (deps.review === undefined) {
     throw new Error("runWithReviewPipeline called without review deps");
@@ -385,7 +436,11 @@ async function runWithReviewPipeline(
       prompt: fullPrompt,
     };
     if (task.sessionId !== null) streamOpts.sessionId = task.sessionId;
-    if (task.workingDir !== null) streamOpts.workingDirectory = task.workingDir;
+    if (workingDirectoryOverride !== null) {
+      streamOpts.workingDirectory = workingDirectoryOverride;
+    } else if (task.workingDir !== null) {
+      streamOpts.workingDirectory = task.workingDir;
+    }
     for await (const msg of deps.agentClient.stream(streamOpts)) {
       msgsConsumed += 1;
       deps.quotaTracker.recordMessage(taskRunId);

--- a/src/worker/workspace.ts
+++ b/src/worker/workspace.ts
@@ -7,9 +7,10 @@
  * Reusa execFile (não exec) — não passa por shell, mais seguro.
  */
 
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { promisify } from "node:util";
+import type { Task } from "@clawde/domain/task";
 import type { Workspace } from "@clawde/domain/workspace";
 
 const exec = promisify(execFile);
@@ -21,6 +22,12 @@ export interface CreateWorkspaceInput {
   readonly baseBranch: string;
   readonly repoRoot: string;
   readonly tmpRoot?: string; // override pra testes
+}
+
+export interface AgentDefinitionLike {
+  readonly frontmatter?: {
+    readonly requiresWorkspace?: boolean;
+  };
 }
 
 function workspacePath(taskRunId: number, tmpRoot = "/tmp"): string {
@@ -94,6 +101,24 @@ export async function listWorktrees(repoRoot: string): Promise<ReadonlyArray<str
     }
   }
   return paths;
+}
+
+export function shouldUseEphemeralWorkspace(
+  _task: Task,
+  agentDef: AgentDefinitionLike | null,
+): boolean {
+  return agentDef?.frontmatter?.requiresWorkspace ?? false;
+}
+
+export function cleanupOrphanWorkspaceSync(
+  repoRoot: string,
+  taskRunId: number,
+  tmpRoot?: string,
+): boolean {
+  const path = workspacePath(taskRunId, tmpRoot);
+  if (!existsSync(path)) return false;
+  execFileSync("git", ["worktree", "remove", "--force", path], { cwd: repoRoot });
+  return true;
 }
 
 export { workspacePath as _workspacePathForTests, featureBranch as _featureBranchForTests };

--- a/tests/integration/workspace-isolation.test.ts
+++ b/tests/integration/workspace-isolation.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EventsRepo } from "@clawde/db/repositories/events";
+import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
+import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
+import { TasksRepo } from "@clawde/db/repositories/tasks";
+import { createLogger } from "@clawde/log";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
+import type { AgentClient, ParsedMessage, RunAgentOptions } from "@clawde/sdk";
+import { LeaseManager, createWorkspace, makeReconciler, processTask } from "@clawde/worker";
+import { type TestDb, makeTestDb } from "../helpers/db.ts";
+
+function initRepo(dir: string): void {
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: dir });
+  writeFileSync(join(dir, "README.md"), "base\n");
+  execFileSync("git", ["add", "."], { cwd: dir });
+  execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd: dir });
+}
+
+class WritingClient implements AgentClient {
+  async *stream(options: RunAgentOptions): AsyncIterable<ParsedMessage> {
+    if (options.workingDirectory !== undefined) {
+      writeFileSync(join(options.workingDirectory, "workspace-output.txt"), "ok\n");
+    }
+    yield { role: "assistant", blocks: [{ type: "text", text: "ok" }] };
+  }
+  async run(): Promise<never> {
+    throw new Error("not used");
+  }
+}
+
+describe("workspace isolation", () => {
+  let testDb: TestDb;
+  let repoRoot: string;
+  let tmpRoot: string;
+  let tasksRepo: TasksRepo;
+  let runsRepo: TaskRunsRepo;
+  let eventsRepo: EventsRepo;
+
+  beforeEach(() => {
+    testDb = makeTestDb();
+    repoRoot = mkdtempSync(join(tmpdir(), "clawde-repo-"));
+    tmpRoot = mkdtempSync(join(tmpdir(), "clawde-ws-"));
+    initRepo(repoRoot);
+    tasksRepo = new TasksRepo(testDb.db);
+    runsRepo = new TaskRunsRepo(testDb.db);
+    eventsRepo = new EventsRepo(testDb.db);
+  });
+
+  afterEach(() => {
+    testDb.cleanup();
+    rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test("task escreve no worktree, não no repo principal", async () => {
+    const task = tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "workspace write",
+      agent: "implementer",
+      sessionId: null,
+      workingDir: repoRoot,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+
+    const result = await processTask(
+      {
+        tasksRepo,
+        runsRepo,
+        eventsRepo,
+        leaseManager: new LeaseManager(runsRepo, eventsRepo, {
+          leaseSeconds: 60,
+          heartbeatSeconds: 999,
+        }),
+        quotaTracker: new QuotaTracker(new QuotaLedgerRepo(testDb.db), DEFAULT_TRACKER_CONFIG),
+        quotaPolicy: makeQuotaPolicy(),
+        agentClient: new WritingClient(),
+        logger: createLogger({ component: "workspace-isolation-test" }),
+        workerId: "w1",
+        workspaceConfig: { tmpRoot, baseBranch: "main" },
+        resolveAgentDefinition: async () => ({ frontmatter: { requiresWorkspace: true } }),
+      },
+      task,
+    );
+
+    expect(result.run.status).toBe("succeeded");
+    expect(existsSync(join(repoRoot, "workspace-output.txt"))).toBe(false);
+    const status = execFileSync("git", ["status", "--porcelain"], { cwd: repoRoot })
+      .toString("utf-8")
+      .trim();
+    expect(status).toBe("");
+  });
+
+  test("reconcile remove worktree órfã de run expirado", async () => {
+    const task = tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "orphan",
+      agent: "implementer",
+      sessionId: null,
+      workingDir: repoRoot,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+    const run = runsRepo.insert(task.id, "w-old");
+    runsRepo.acquireLease(run.id, 60);
+    testDb.db.exec(
+      `UPDATE task_runs SET lease_until = datetime('now', '-10 seconds') WHERE id = ${run.id}`,
+    );
+    const ws = await createWorkspace({
+      taskRunId: run.id,
+      taskId: task.id,
+      slug: "orphan",
+      baseBranch: "main",
+      repoRoot,
+      tmpRoot,
+    });
+    expect(existsSync(ws.path)).toBe(true);
+
+    const rec = makeReconciler(runsRepo, eventsRepo, {
+      tasksRepo,
+      workspaceTmpRoot: tmpRoot,
+    }).reconcile("w-new");
+    expect(rec.cleanedOrphans).toBeGreaterThanOrEqual(1);
+    expect(existsSync(ws.path)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes sub-phase P2.1 in EXECUTION_BACKLOG.md.\n\n## Tasks included\n- T-041: WorkspaceConfig em RunnerDeps\n- T-042: processTask com create/remove workspace ephemeral\n- T-043: shouldUseEphemeralWorkspace consultando agent definition\n- T-044: reconcile com cleanup best-effort de worktree órfã\n- T-045: teste de isolamento (write no worktree, repo principal clean)\n- T-046: teste de cleanup e remoção de órfã no reconcile\n\n## What changed\nIntegrei criação de workspace ephemeral no fluxo de execução do worker quando o agente exige workspace, com cleanup pós-run e override de cwd para o worktree. Também adicionei cleanup best-effort de órfãos no reconcile de leases expirados, e testes de integração cobrindo isolamento e limpeza.\n\n## Acceptance criteria validated\n- [x] T-041 criteria\n- [x] T-042 criteria\n- [x] T-043 criteria\n- [x] T-044 criteria\n- [x] T-045 criteria\n- [x] T-046 criteria\n\n## CI\n- [x]  clean\n- [x] Checked 162 files in 1071ms. No fixes applied.
Found 2 warnings. clean (com 2 warnings históricos fora do escopo)\n- [x] bun test v1.3.13 (bf2e2cec)
applied: 1, 2, 3
applied: 1, 2, 3
{
  "applied": [
    1,
    2,
    3
  ]
}
applied: 1, 2, 3
applied: 1, 2, 3
{"ts":"2026-04-29T22:53:09.054Z","level":"INFO","msg":"task processing","component":"lease-reconcile-test","taskId":1,"agent":"default","priority":"NORMAL"}
{"ts":"2026-04-29T22:53:09.055Z","level":"INFO","msg":"task finished","component":"lease-reconcile-test","taskId":1,"status":"succeeded","msgs":1}
{"ts":"2026-04-29T22:53:16.137Z","level":"INFO","msg":"task processing","component":"workspace-isolation-test","taskId":1,"agent":"implementer","priority":"NORMAL"}
{"ts":"2026-04-29T22:53:16.167Z","level":"INFO","msg":"task finished","component":"workspace-isolation-test","taskId":1,"status":"succeeded","msgs":1} (suite focal de worker/workspace/reconcile)\n\n## Notes for reviewer\nFoco em  (runner),  (workspace.ts) e  com cleanup de órfãs.\n\n🤖 Implemented by Codex