### PR TITLE
P0.1 followup: T-008 --max-tasks flag + break-on-defer

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -77,7 +77,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-005 — merged, PR #2, 2026-04-29
 - [x] T-006 — merged, PR #2, 2026-04-29
 - [x] T-007 — merged, PR #2, 2026-04-29
-- [ ] T-008 — pending — unlocked after P1.2 (T-029)
+- [ ] T-008 — in-review, PR followup — task/P0.1-followup-quota-gate
 - [x] T-009 — merged, PR #2, 2026-04-29
 - [x] T-010 — merged, PR #2, 2026-04-29
 - [x] T-011 — merged, PR #2, 2026-04-29

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -10,14 +10,47 @@ import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, setMinLevel } from "@clawde/log";
 import { QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
 import { RealAgentClient } from "@clawde/sdk";
-import { LeaseManager, makeReconciler, processNextPending } from "./index.ts";
+import { LeaseManager, type RunnerDeps, makeReconciler, processNextPending } from "./index.ts";
+
+const DEFAULT_MAX_TASKS = 50;
 
 function expandHome(p: string): string {
   if (p.startsWith("~/") || p === "~") return p.replace(/^~/, homedir());
   return p;
 }
 
-export async function bootstrap(): Promise<void> {
+export function parseMaxTasks(argv: ReadonlyArray<string>, fallback = DEFAULT_MAX_TASKS): number {
+  const idx = argv.indexOf("--max-tasks");
+  if (idx < 0 || idx + 1 >= argv.length) return fallback;
+  const raw = argv[idx + 1];
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export type LoopExitReason = "empty" | "deferred" | "max_tasks";
+
+export interface LoopResult {
+  readonly processed: number;
+  readonly exitReason: LoopExitReason;
+}
+
+export async function runProcessLoop(deps: RunnerDeps, maxTasks: number): Promise<LoopResult> {
+  let processed = 0;
+  while (processed < maxTasks) {
+    const result = await processNextPending(deps);
+    if (result === null) return { processed, exitReason: "empty" };
+    if (result.agentResult.stopReason === "deferred") {
+      return { processed, exitReason: "deferred" };
+    }
+    processed += 1;
+  }
+  return { processed, exitReason: "max_tasks" };
+}
+
+export async function bootstrap(
+  argv: ReadonlyArray<string> = process.argv.slice(2),
+): Promise<void> {
   const config = loadConfig();
   setMinLevel(config.clawde.log_level);
   const logger = createLogger({ service: "worker" });
@@ -46,10 +79,9 @@ export async function bootstrap(): Promise<void> {
       reenqueued_count: reconcileResult.reenqueued.length,
       cleaned_orphans: reconcileResult.cleanedOrphans,
     });
-    const maxTasks = 50;
-    let processed = 0;
-    while (processed < maxTasks) {
-      const result = await processNextPending({
+    const maxTasks = parseMaxTasks(argv);
+    const loop = await runProcessLoop(
+      {
         tasksRepo,
         runsRepo,
         eventsRepo,
@@ -60,11 +92,14 @@ export async function bootstrap(): Promise<void> {
         logger,
         workerId,
         workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
-      });
-      if (result === null) break;
-      processed += 1;
-    }
-    logger.info("worker idle", { processed });
+      },
+      maxTasks,
+    );
+    logger.info("worker idle", {
+      processed: loop.processed,
+      max_tasks: maxTasks,
+      exit_reason: loop.exitReason,
+    });
   } finally {
     closeDb(db);
   }

--- a/tests/integration/worker-loop.test.ts
+++ b/tests/integration/worker-loop.test.ts
@@ -1,0 +1,107 @@
+/**
+ * T-008 followup: runProcessLoop break-on-defer + max-tasks ceiling.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EventsRepo } from "@clawde/db/repositories/events";
+import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
+import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
+import { TasksRepo } from "@clawde/db/repositories/tasks";
+import { createLogger, resetLogSink, setLogSink } from "@clawde/log";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
+import { LeaseManager, type RunnerDeps } from "@clawde/worker";
+import { runProcessLoop } from "@clawde/worker/main";
+import { type TestDb, makeTestDb } from "../helpers/db.ts";
+import { MockAgentClient, assistantText } from "../mocks/sdk-mock.ts";
+
+describe("worker runProcessLoop", () => {
+  let testDb: TestDb;
+  let deps: RunnerDeps;
+  let tasksRepo: TasksRepo;
+  let runsRepo: TaskRunsRepo;
+  let quotaRepo: QuotaLedgerRepo;
+  let mockClient: MockAgentClient;
+
+  beforeEach(() => {
+    testDb = makeTestDb();
+    setLogSink(() => {});
+    tasksRepo = new TasksRepo(testDb.db);
+    runsRepo = new TaskRunsRepo(testDb.db);
+    const eventsRepo = new EventsRepo(testDb.db);
+    quotaRepo = new QuotaLedgerRepo(testDb.db);
+    const tracker = new QuotaTracker(quotaRepo, DEFAULT_TRACKER_CONFIG);
+    mockClient = new MockAgentClient();
+    deps = {
+      tasksRepo,
+      runsRepo,
+      eventsRepo,
+      leaseManager: new LeaseManager(runsRepo, eventsRepo, {
+        leaseSeconds: 60,
+        heartbeatSeconds: 999,
+      }),
+      quotaTracker: tracker,
+      quotaPolicy: makeQuotaPolicy(),
+      agentClient: mockClient,
+      logger: createLogger({ component: "loop-test" }),
+      workerId: "worker-loop",
+    };
+  });
+  afterEach(() => {
+    testDb.cleanup();
+    resetLogSink();
+  });
+
+  function insertTask(prompt: string): void {
+    tasksRepo.insert({
+      priority: "NORMAL",
+      prompt,
+      agent: "default",
+      sessionId: null,
+      workingDir: null,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+  }
+
+  test("fila vazia retorna exitReason=empty, processed=0", async () => {
+    const result = await runProcessLoop(deps, 50);
+    expect(result.processed).toBe(0);
+    expect(result.exitReason).toBe("empty");
+  });
+
+  test("processa todas até maxTasks=1 e retorna max_tasks quando há mais", async () => {
+    insertTask("a");
+    insertTask("b");
+    mockClient.enqueueResponse({ messages: [assistantText("ok")] });
+    mockClient.enqueueResponse({ messages: [assistantText("ok")] });
+
+    const result = await runProcessLoop(deps, 1);
+    expect(result.processed).toBe(1);
+    expect(result.exitReason).toBe("max_tasks");
+  });
+
+  test("primeira task deferida quebra o loop antes de tocar a segunda", async () => {
+    // quota esgotada antes do loop começar
+    quotaRepo.insert({
+      msgsConsumed: 1000,
+      windowStart: quotaRepo.currentWindowStart(),
+      plan: "max5x",
+      peakMultiplier: 1.0,
+      taskRunId: null,
+    });
+    insertTask("first");
+    insertTask("second");
+
+    const result = await runProcessLoop(deps, 50);
+    expect(result.exitReason).toBe("deferred");
+    expect(result.processed).toBe(0);
+
+    // Apenas a primeira task ganhou not_before; a segunda continua sem run.
+    const firstRun = runsRepo.findLatestByTaskId(1);
+    const secondRun = runsRepo.findLatestByTaskId(2);
+    expect(firstRun?.notBefore).not.toBeNull();
+    expect(secondRun).toBeNull();
+  });
+});

--- a/tests/unit/worker/main.parse-max-tasks.test.ts
+++ b/tests/unit/worker/main.parse-max-tasks.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { parseMaxTasks } from "@clawde/worker/main";
+
+describe("worker/main parseMaxTasks", () => {
+  test("default 50 quando flag ausente", () => {
+    expect(parseMaxTasks([])).toBe(50);
+    expect(parseMaxTasks(["--other", "foo"])).toBe(50);
+  });
+
+  test("respeita valor de --max-tasks", () => {
+    expect(parseMaxTasks(["--max-tasks", "10"])).toBe(10);
+    expect(parseMaxTasks(["--max-tasks", "200"])).toBe(200);
+  });
+
+  test("ignora valor não-numérico ou ≤ 0", () => {
+    expect(parseMaxTasks(["--max-tasks", "abc"])).toBe(50);
+    expect(parseMaxTasks(["--max-tasks", "0"])).toBe(50);
+    expect(parseMaxTasks(["--max-tasks", "-5"])).toBe(50);
+  });
+
+  test("ignora flag sem valor", () => {
+    expect(parseMaxTasks(["--max-tasks"])).toBe(50);
+  });
+
+  test("respeita fallback custom", () => {
+    expect(parseMaxTasks([], 25)).toBe(25);
+    expect(parseMaxTasks(["--max-tasks", "abc"], 25)).toBe(25);
+  });
+});


### PR DESCRIPTION
Closes T-008 from P0.1 (originally blocked on T-029 from P1.2; unlocked after PR #5 merged).

## What

`worker/main.ts` now honors the full T-008 spec:

1. **`--max-tasks <N>` flag** — replaces hardcoded `maxTasks = 50`. Falls back to 50 on missing/invalid input.
2. **Break-on-defer** — loop exits the moment `processNextPending` returns a deferred result, instead of iterating all pending tasks just to defer them all.
3. **`runProcessLoop` extracted** — the loop body is now a pure function `(deps, maxTasks) → { processed, exitReason }`. Testable without subprocess.

## Acceptance criteria validated

- [x] T-008: loop ≤ maxTasks tasks per invocation, configurable via `--max-tasks`
- [x] T-008: deferred result ends the loop without error
- [x] T-008: empty queue ends the loop with exit 0

## Tests

- `tests/unit/worker/main.parse-max-tasks.test.ts` — 5 tests for flag parsing
- `tests/integration/worker-loop.test.ts` — 3 tests:
  - empty queue → `exitReason=empty`, processed=0
  - 2 tasks pending, `maxTasks=1` → 1 processed, `exitReason=max_tasks`
  - quota esgotada + 2 tasks → first task gets `not_before` set, second task untouched (loop broke), `exitReason=deferred`, processed=0

## CI

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun test` 593/594 (1 flaky histórico do `findExpiredLeases`)

## Notes for reviewer

This commit also bumps the T-008 spec into "fully met" — previously the loop was implemented (P0.1) and the quota gate was injected (P1.2), but `--max-tasks` and break-on-defer were missing. Now both are in.

Cross-wave dependency from `STATUS.md` ("T-008 do P0.1 está blocked-on T-029") can be cleared after this merges.

🤖 Implemented by Claude Sonnet 4.6