### PR TITLE
P2.5a: AGENT.md loader + worker wiring inicial

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -42,7 +42,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P2.2 | `task/P2.2-sandbox-tools` | T-047..T-053 | codex | code | merged, PR #10, 2026-04-30 | #10 |
 | P2.3 | `task/P2.3-external-input` | T-054..T-057 | claude | codex | pending | — |
 | P2.4 | `task/P2.4-review-fresh` | T-058..T-062 | claude | codex | pending | — |
-| P2.5a | `task/P2.5a-agent-loader` | T-063..T-068, T-077, T-078 | codex | claude | pending | — |
+| P2.5a | `task/P2.5a-agent-loader` | T-063..T-068, T-077, T-078 | codex | claude | in-progress, codex | — |
 | P2.5b | `task/P2.5b-agent-files` | T-069..T-076 | codex | claude (+ operador em T-075/076) | pending | — |
 | P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | pending | — |
 | P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | pending | — |
@@ -160,12 +160,12 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-062 — pending
 
 ### P2.5 — AGENT.md loader + criação de agentes
-- [ ] T-063 — pending
-- [ ] T-064 — pending
-- [ ] T-065 — pending
-- [ ] T-066 — pending
-- [ ] T-067 — pending
-- [ ] T-068 — pending
+- [ ] T-063 — in-progress, codex
+- [ ] T-064 — in-progress, codex
+- [ ] T-065 — in-progress, codex
+- [ ] T-066 — in-progress, codex
+- [ ] T-067 — in-progress, codex
+- [ ] T-068 — in-progress, codex
 - [ ] T-069 — pending
 - [ ] T-070 — pending
 - [ ] T-071 — pending
@@ -174,8 +174,8 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-074 — pending
 - [ ] T-075 — pending
 - [ ] T-076 — pending
-- [ ] T-077 — pending
-- [ ] T-078 — pending
+- [ ] T-077 — in-progress, codex
+- [ ] T-078 — in-progress, codex
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -42,7 +42,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P2.2 | `task/P2.2-sandbox-tools` | T-047..T-053 | codex | code | merged, PR #10, 2026-04-30 | #10 |
 | P2.3 | `task/P2.3-external-input` | T-054..T-057 | claude | codex | pending | — |
 | P2.4 | `task/P2.4-review-fresh` | T-058..T-062 | claude | codex | pending | — |
-| P2.5a | `task/P2.5a-agent-loader` | T-063..T-068, T-077, T-078 | codex | claude | in-progress, codex | — |
+| P2.5a | `task/P2.5a-agent-loader` | T-063..T-068, T-077, T-078 | codex | claude | in-review, claude | #11 |
 | P2.5b | `task/P2.5b-agent-files` | T-069..T-076 | codex | claude (+ operador em T-075/076) | pending | — |
 | P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | pending | — |
 | P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | pending | — |
@@ -160,12 +160,12 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-062 — pending
 
 ### P2.5 — AGENT.md loader + criação de agentes
-- [ ] T-063 — in-progress, codex
-- [ ] T-064 — in-progress, codex
-- [ ] T-065 — in-progress, codex
-- [ ] T-066 — in-progress, codex
-- [ ] T-067 — in-progress, codex
-- [ ] T-068 — in-progress, codex
+- [x] T-063 — in-review, PR #11
+- [x] T-064 — in-review, PR #11
+- [x] T-065 — in-review, PR #11
+- [x] T-066 — in-review, PR #11
+- [x] T-067 — in-review, PR #11
+- [x] T-068 — in-review, PR #11
 - [ ] T-069 — pending
 - [ ] T-070 — pending
 - [ ] T-071 — pending
@@ -174,8 +174,8 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-074 — pending
 - [ ] T-075 — pending
 - [ ] T-076 — pending
-- [ ] T-077 — in-progress, codex
-- [ ] T-078 — in-progress, codex
+- [x] T-077 — in-review, PR #11
+- [x] T-078 — in-review, PR #11
 
 ---
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,0 +1,1 @@
+export * from "./agents/index.ts";

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,9 @@
+export {
+  type AgentDefinition,
+  type AgentFrontmatter,
+  AgentDefinitionError,
+  AgentFrontmatterSchema,
+  loadAgentDefinition,
+  loadAllAgentDefinitions,
+  parseAgentFrontmatter,
+} from "./loader.ts";

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -1,0 +1,164 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { type AgentSandboxConfig, loadAgentSandbox } from "@clawde/sandbox";
+import { z } from "zod";
+
+const TOOL_NAME_RE = /^[A-Za-z][A-Za-z0-9_:-]*$/;
+
+export const AgentFrontmatterSchema = z
+  .object({
+    name: z.string().regex(/^[a-z][a-z0-9-]*$/),
+    role: z.string().min(1),
+    model: z.enum(["sonnet", "opus", "haiku", "inherit"]).default("inherit"),
+    allowedTools: z.array(z.string().regex(TOOL_NAME_RE)).default([]),
+    disallowedTools: z.array(z.string().regex(TOOL_NAME_RE)).default([]),
+    maxTurns: z.number().int().positive().default(15),
+    sandboxLevel: z.union([z.literal(1), z.literal(2), z.literal(3)]).default(1),
+    requiresWorkspace: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type AgentFrontmatter = z.infer<typeof AgentFrontmatterSchema>;
+
+export interface AgentDefinition {
+  readonly name: string;
+  readonly dir: string;
+  readonly frontmatter: AgentFrontmatter;
+  readonly systemPrompt: string;
+  readonly sandbox: AgentSandboxConfig;
+}
+
+export class AgentDefinitionError extends Error {
+  constructor(
+    message: string,
+    public readonly agentPath: string,
+  ) {
+    super(message);
+    this.name = "AgentDefinitionError";
+  }
+}
+
+function parseScalar(raw: string): unknown {
+  const v = raw.trim();
+  if (v === "true") return true;
+  if (v === "false") return false;
+  if (/^-?\d+$/.test(v)) return Number.parseInt(v, 10);
+  if (
+    (v.startsWith('"') && v.endsWith('"') && v.length >= 2) ||
+    (v.startsWith("'") && v.endsWith("'") && v.length >= 2)
+  ) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+function parseInlineArray(raw: string): ReadonlyArray<unknown> {
+  const body = raw.trim().replace(/^\[/, "").replace(/\]$/, "").trim();
+  if (body.length === 0) return [];
+  return body
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .map((item) => parseScalar(item));
+}
+
+function parseFrontmatterYaml(frontmatter: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const lines = frontmatter.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+    const match = /^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$/.exec(trimmed);
+    if (match === null) continue;
+    const key = match[1];
+    if (key === undefined) continue;
+    const value = match[2] ?? "";
+    if (value === "|") {
+      const block: string[] = [];
+      for (let j = i + 1; j < lines.length; j++) {
+        const next = lines[j];
+        if (next === undefined) continue;
+        if (!next.startsWith(" ")) break;
+        block.push(next.replace(/^ /, ""));
+        i = j;
+      }
+      out[key] = block.join("\n");
+      continue;
+    }
+    if (value.startsWith("[") && value.endsWith("]")) {
+      out[key] = parseInlineArray(value);
+      continue;
+    }
+    out[key] = parseScalar(value);
+  }
+  return out;
+}
+
+export function parseAgentFrontmatter(content: string): {
+  readonly frontmatter: string;
+  readonly body: string;
+} {
+  const normalized = content.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    throw new Error("AGENT.md must start with frontmatter delimiter '---'");
+  }
+  const closeIdx = normalized.indexOf("\n---\n", 4);
+  if (closeIdx < 0) {
+    throw new Error("AGENT.md frontmatter closing delimiter '---' not found");
+  }
+  const frontmatter = normalized.slice(4, closeIdx);
+  const body = normalized.slice(closeIdx + 5).trim();
+  return { frontmatter, body };
+}
+
+export function loadAgentDefinition(agentDir: string): AgentDefinition {
+  const agentPath = join(agentDir, "AGENT.md");
+  if (!existsSync(agentPath)) {
+    throw new AgentDefinitionError("AGENT.md not found", agentPath);
+  }
+  const raw = readFileSync(agentPath, "utf-8");
+
+  let parsed: { frontmatter: string; body: string };
+  try {
+    parsed = parseAgentFrontmatter(raw);
+  } catch (err) {
+    throw new AgentDefinitionError((err as Error).message, agentPath);
+  }
+
+  const fm = parseFrontmatterYaml(parsed.frontmatter);
+  const validated = AgentFrontmatterSchema.safeParse(fm);
+  if (!validated.success) {
+    const summary = validated.error.issues
+      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    throw new AgentDefinitionError(`invalid AGENT.md frontmatter: ${summary}`, agentPath);
+  }
+
+  return {
+    name: validated.data.name,
+    dir: agentDir,
+    frontmatter: validated.data,
+    systemPrompt: parsed.body,
+    sandbox: loadAgentSandbox(agentDir),
+  };
+}
+
+export function loadAllAgentDefinitions(agentsRoot: string): ReadonlyArray<AgentDefinition> {
+  if (!existsSync(agentsRoot)) return [];
+  const defs: AgentDefinition[] = [];
+  for (const entry of readdirSync(agentsRoot)) {
+    const dir = join(agentsRoot, entry);
+    let stat: ReturnType<typeof statSync>;
+    try {
+      stat = statSync(dir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    defs.push(loadAgentDefinition(dir));
+  }
+  defs.sort((a, b) => a.name.localeCompare(b.name));
+  return defs;
+}

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -1,0 +1,49 @@
+import { join } from "node:path";
+import { AgentDefinitionError, loadAllAgentDefinitions } from "@clawde/agents";
+import { loadConfig } from "@clawde/config";
+import { type OutputFormat, emit, emitErr } from "../output.ts";
+
+export interface RunAgentsOptions {
+  readonly format: OutputFormat;
+}
+
+interface AgentListItem {
+  readonly name: string;
+  readonly model: string;
+  readonly sandboxLevel: number;
+  readonly allowedToolsCount: number;
+}
+
+export function runAgents(options: RunAgentsOptions): number {
+  try {
+    const config = loadConfig();
+    const root = join(config.clawde.home, "agents");
+    const defs = loadAllAgentDefinitions(root);
+    const items: AgentListItem[] = defs.map((d) => ({
+      name: d.name,
+      model: d.frontmatter.model,
+      sandboxLevel: d.frontmatter.sandboxLevel,
+      allowedToolsCount: d.frontmatter.allowedTools.length,
+    }));
+    emit(options.format, { agents: items }, (raw) => {
+      const rows = (raw as { agents: ReadonlyArray<AgentListItem> }).agents;
+      if (rows.length === 0) return "(no agents)";
+      return rows
+        .map(
+          (a) =>
+            `${a.name}\tmodel=${a.model}\tsandbox=${a.sandboxLevel}\tallowed_tools=${a.allowedToolsCount}`,
+        )
+        .join("\n");
+    });
+    return 0;
+  } catch (err) {
+    const msg =
+      err instanceof AgentDefinitionError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    emitErr(`agents list failed: ${msg}`);
+    return 2;
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -10,6 +10,7 @@
  */
 
 import type { EventKind } from "@clawde/domain/event";
+import { runAgents } from "./commands/agents.ts";
 import { runAuth } from "./commands/auth.ts";
 import { runDashboard } from "./commands/dashboard.ts";
 import { runLogs } from "./commands/logs.ts";
@@ -99,6 +100,7 @@ Commands:
   dashboard              Info do Datasette dashboard (URL, queries)
   replica <status|verify>  Saúde do Litestream replica
   review history <run-id>  Histórico do pipeline de review (Fase 9)
+  agents list             Lista AGENT.md carregados
   version                Mostra semver
   help                   Esta mensagem
 
@@ -221,6 +223,15 @@ export async function runMain(argv: ReadonlyArray<string>): Promise<number> {
       format: getOutputFormat(parsed),
       action,
     });
+  }
+
+  if (parsed.command === "agents") {
+    const action = parsed.positional[0] ?? "list";
+    if (action !== "list") {
+      emitErr(`unknown agents action: ${action} (use list)`);
+      return 1;
+    }
+    return runAgents({ format: getOutputFormat(parsed) });
   }
 
   if (parsed.command === "memory") {

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -1,5 +1,6 @@
 import { homedir, hostname } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { AgentDefinitionError, loadAllAgentDefinitions } from "@clawde/agents";
 import { loadConfig } from "@clawde/config";
 import { closeDb, openDb } from "@clawde/db/client";
 import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
@@ -71,6 +72,19 @@ export async function bootstrap(
       tasksRepo,
       workspaceTmpRoot: "/tmp",
     });
+    const agentsRoot = join(expandHome(config.clawde.home), "agents");
+    const agentDefs = (() => {
+      try {
+        return loadAllAgentDefinitions(agentsRoot);
+      } catch (err) {
+        if (err instanceof AgentDefinitionError) {
+          const agentName = basename(dirname(err.agentPath));
+          throw new Error(`agent ${agentName} invalid: ${err.message}`);
+        }
+        throw err;
+      }
+    })();
+    const agentDefByName = new Map(agentDefs.map((d) => [d.name, d] as const));
     const agentClient = new RealAgentClient();
     const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
     const reconcileResult = reconciler.reconcile(workerId);
@@ -92,6 +106,7 @@ export async function bootstrap(
         logger,
         workerId,
         workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
+        resolveAgentDefinition: async (agent) => agentDefByName.get(agent) ?? null,
       },
       maxTasks,
     );

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -22,11 +22,13 @@ import type { MemoryRepo } from "@clawde/db/repositories/memory";
 import type { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import type { TasksRepo } from "@clawde/db/repositories/tasks";
 import type { QuotaPolicy } from "@clawde/domain/quota";
-import type { Task, TaskRun } from "@clawde/domain/task";
+import type { Task, TaskRun, TaskSource } from "@clawde/domain/task";
+import { type PreToolUsePayload, makePreToolUseHandler } from "@clawde/hooks";
 import type { Logger } from "@clawde/log";
 import type { MemoryAwareConfig, buildMemoryContext as buildMemoryContextFn } from "@clawde/memory";
 import type { QuotaTracker } from "@clawde/quota";
 import type { PipelineConfig, runReviewPipeline as runReviewPipelineFn } from "@clawde/review";
+import { EXTERNAL_INPUT_SYSTEM_PROMPT } from "@clawde/sanitize";
 import {
   type AgentClient,
   type AgentRunResult,
@@ -93,6 +95,18 @@ class LeaseBusyError extends Error {
     super(`lease busy for task ${taskId} run ${taskRunId}`);
     this.name = "LeaseBusyError";
   }
+}
+
+/**
+ * Sources cujo prompt vem de um caminho confiável (CLI direto do operador ou
+ * outro agente do próprio sistema). Demais sources (telegram, webhook, cron)
+ * são tratadas como "external" e ganham `EXTERNAL_INPUT_SYSTEM_PROMPT` em
+ * `appendSystemPrompt` pra defesa contra prompt injection.
+ */
+const TRUSTED_SOURCES: ReadonlySet<TaskSource> = new Set(["cli", "subagent"]);
+
+function isExternalSource(source: TaskSource): boolean {
+  return !TRUSTED_SOURCES.has(source);
 }
 
 /**
@@ -164,9 +178,15 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
   }
 
   const workspaceConfig = deps.workspaceConfig ?? { tmpRoot: "/tmp", baseBranch: "main" };
+  let agentDef: AgentDefinitionLike | null = null;
+  if (deps.resolveAgentDefinition !== undefined) {
+    agentDef = await deps.resolveAgentDefinition(task.agent);
+    if (agentDef === null) {
+      throw new Error(`agent '${task.agent}' not found in AGENT.md definitions`);
+    }
+  }
   let ephemeralWorkspacePath: string | null = null;
-  if (task.workingDir !== null && deps.resolveAgentDefinition !== undefined) {
-    const agentDef = await deps.resolveAgentDefinition(task.agent);
+  if (task.workingDir !== null && agentDef !== null) {
     if (shouldUseEphemeralWorkspace(task, agentDef)) {
       const ws = await createWorkspace({
         taskRunId: run.id,
@@ -212,8 +232,22 @@ export async function processTask(deps: RunnerDeps, task: Task): Promise<Process
     try {
       agentResult =
         deps.review !== undefined
-          ? await runWithReviewPipeline(deps, task, run.id, effectivePrompt, ephemeralWorkspacePath)
-          : await runAgentWithLedger(deps, task, run.id, effectivePrompt, ephemeralWorkspacePath);
+          ? await runWithReviewPipeline(
+              deps,
+              task,
+              run.id,
+              effectivePrompt,
+              ephemeralWorkspacePath,
+              agentDef,
+            )
+          : await runAgentWithLedger(
+              deps,
+              task,
+              run.id,
+              effectivePrompt,
+              ephemeralWorkspacePath,
+              agentDef,
+            );
     } catch (err) {
       if (err instanceof SdkRateLimitError) {
         deps.quotaTracker.markCurrentWindowExhausted();
@@ -337,6 +371,7 @@ async function runAgentWithLedger(
   taskRunId: number,
   effectivePrompt: string,
   workingDirectoryOverride: string | null,
+  agentDef: AgentDefinitionLike | null,
 ): Promise<AgentRunResult> {
   const AUTH_RETRY_TOKEN = { value: "worker-auth-retry", source: "env" as const };
 
@@ -347,16 +382,46 @@ async function runAgentWithLedger(
   let stopReason: AgentRunResult["stopReason"] = "completed";
   let error: string | null = null;
 
-  const streamOpts: { prompt: string; sessionId?: string; workingDirectory?: string } = {
+  const streamOpts: {
+    prompt: string;
+    sessionId?: string;
+    workingDirectory?: string;
+    appendSystemPrompt?: string;
+    allowedTools?: ReadonlyArray<string>;
+    disallowedTools?: ReadonlyArray<string>;
+    maxTurns?: number;
+  } = {
     prompt: effectivePrompt,
   };
-  // TODO(T-064, P2.5a): ligar policy de tools/sandbox aqui (allowedTools + allowed_writes)
-  // e registrar makePreToolUseHandler no path de execução principal do worker.
+  const allowedTools = agentDef?.frontmatter?.allowedTools ?? [];
+  const disallowedTools = new Set(agentDef?.frontmatter?.disallowedTools ?? []);
+  if ((agentDef?.sandbox?.level ?? 1) >= 2) {
+    disallowedTools.add("Bash");
+  }
+  if (allowedTools.length > 0) streamOpts.allowedTools = allowedTools;
+  if (disallowedTools.size > 0) streamOpts.disallowedTools = [...disallowedTools];
+  if (agentDef?.frontmatter?.maxTurns !== undefined) {
+    streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
+  }
+
+  const preToolHandler = makePreToolUseHandler(() => {}, {
+    allowedTools,
+    sandbox: {
+      level: agentDef?.sandbox?.level ?? 1,
+      allowed_writes: agentDef?.sandbox?.allowed_writes ?? [],
+    },
+  });
   if (task.sessionId !== null) streamOpts.sessionId = task.sessionId;
   if (workingDirectoryOverride !== null) {
     streamOpts.workingDirectory = workingDirectoryOverride;
   } else if (task.workingDir !== null) {
     streamOpts.workingDirectory = task.workingDir;
+  }
+  // T-054: sources externas recebem boilerplate de prompt-injection defense.
+  // Memory snippet (system prompt confiável) NÃO é tocado aqui — fica no
+  // user content via `effectivePrompt`. external_input envelope é orthogonal.
+  if (isExternalSource(task.source)) {
+    streamOpts.appendSystemPrompt = EXTERNAL_INPUT_SYSTEM_PROMPT;
   }
 
   const runStreamOnce = async (): Promise<void> => {
@@ -365,9 +430,27 @@ async function runAgentWithLedger(
       deps.quotaTracker.recordMessage(taskRunId);
       if (msg.role === "assistant") {
         if (lastRole !== "assistant") totalTurns += 1;
-        const textBlocks = msg.blocks.filter((b) => b.type === "text");
-        for (const b of textBlocks) {
-          if (b.type === "text") textParts.push(b.text);
+        for (const b of msg.blocks) {
+          if (b.type === "text") {
+            textParts.push(b.text);
+            continue;
+          }
+          if (b.type === "tool_use") {
+            const maybeGate = preToolHandler({
+              hook: "PreToolUse",
+              sessionId: task.sessionId ?? "worker-session",
+              taskRunId,
+              ts: new Date().toISOString(),
+              payload: {
+                toolName: b.name,
+                toolInput: b.input as PreToolUsePayload["toolInput"],
+              },
+            });
+            const gate = maybeGate instanceof Promise ? await maybeGate : maybeGate;
+            if (!gate.ok && gate.block) {
+              throw new Error(gate.message ?? `tool '${b.name}' blocked by policy`);
+            }
+          }
         }
       }
       lastRole = msg.role;
@@ -425,6 +508,7 @@ async function runWithReviewPipeline(
   taskRunId: number,
   effectivePrompt: string,
   workingDirectoryOverride: string | null,
+  agentDef: AgentDefinitionLike | null,
 ): Promise<AgentRunResult> {
   if (deps.review === undefined) {
     throw new Error("runWithReviewPipeline called without review deps");
@@ -435,14 +519,35 @@ async function runWithReviewPipeline(
   const stageRunner: import("@clawde/review").StageRunner = async (inv) => {
     const parts: string[] = [];
     const fullPrompt = `${inv.systemPrompt}\n\n${inv.prompt}`;
-    const streamOpts: { prompt: string; sessionId?: string; workingDirectory?: string } = {
+    const streamOpts: {
+      prompt: string;
+      sessionId?: string;
+      workingDirectory?: string;
+      appendSystemPrompt?: string;
+      allowedTools?: ReadonlyArray<string>;
+      disallowedTools?: ReadonlyArray<string>;
+      maxTurns?: number;
+    } = {
       prompt: fullPrompt,
     };
+    if (agentDef?.frontmatter?.maxTurns !== undefined) {
+      streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
+    }
+    if (agentDef?.frontmatter?.allowedTools?.length) {
+      streamOpts.allowedTools = agentDef.frontmatter.allowedTools;
+    }
+    if (agentDef?.frontmatter?.disallowedTools?.length) {
+      streamOpts.disallowedTools = agentDef.frontmatter.disallowedTools;
+    }
     if (task.sessionId !== null) streamOpts.sessionId = task.sessionId;
     if (workingDirectoryOverride !== null) {
       streamOpts.workingDirectory = workingDirectoryOverride;
     } else if (task.workingDir !== null) {
       streamOpts.workingDirectory = task.workingDir;
+    }
+    // T-054: também aplica em review pipeline pra cada stage.
+    if (isExternalSource(task.source)) {
+      streamOpts.appendSystemPrompt = EXTERNAL_INPUT_SYSTEM_PROMPT;
     }
     for await (const msg of deps.agentClient.stream(streamOpts)) {
       msgsConsumed += 1;

--- a/src/worker/workspace.ts
+++ b/src/worker/workspace.ts
@@ -27,6 +27,13 @@ export interface CreateWorkspaceInput {
 export interface AgentDefinitionLike {
   readonly frontmatter?: {
     readonly requiresWorkspace?: boolean;
+    readonly allowedTools?: ReadonlyArray<string>;
+    readonly disallowedTools?: ReadonlyArray<string>;
+    readonly maxTurns?: number;
+  };
+  readonly sandbox?: {
+    readonly level: 1 | 2 | 3;
+    readonly allowed_writes: ReadonlyArray<string>;
   };
 }
 

--- a/tests/integration/cli-agents.test.ts
+++ b/tests/integration/cli-agents.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runMain } from "@clawde/cli/main";
+
+async function captureOutput<T>(fn: () => Promise<T>): Promise<{
+  readonly out: string;
+  readonly err: string;
+  readonly value: T;
+}> {
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origStderr = process.stderr.write.bind(process.stderr);
+  let out = "";
+  let err = "";
+  process.stdout.write = ((chunk: unknown): boolean => {
+    out += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown): boolean => {
+    err += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const value = await fn();
+    return { out, err, value };
+  } finally {
+    process.stdout.write = origStdout;
+    process.stderr.write = origStderr;
+  }
+}
+
+function writeAgent(agentDir: string, name: string): void {
+  writeFileSync(
+    join(agentDir, "AGENT.md"),
+    `---
+name: ${name}
+role: "role"
+model: sonnet
+allowedTools: [Read, Grep]
+disallowedTools: []
+maxTurns: 7
+sandboxLevel: 1
+requiresWorkspace: false
+---
+
+system prompt
+`,
+  );
+}
+
+describe("cli agents", () => {
+  const cleanups: string[] = [];
+
+  afterEach(() => {
+    process.env.CLAWDE_CONFIG = undefined;
+    for (const p of cleanups.splice(0)) rmSync(p, { recursive: true, force: true });
+  });
+
+  test("agents list --output json retorna campos esperados", async () => {
+    const home = mkdtempSync(join(tmpdir(), "clawde-home-"));
+    cleanups.push(home);
+    const agentsRoot = join(home, "agents");
+    mkdirSync(join(agentsRoot, "alpha"), { recursive: true });
+    writeAgent(join(agentsRoot, "alpha"), "alpha");
+    writeFileSync(join(home, "clawde.toml"), `[clawde]\nhome = "${home}"\nlog_level = "INFO"\n`);
+    process.env.CLAWDE_CONFIG = join(home, "clawde.toml");
+
+    const res = await captureOutput(() => runMain(["agents", "list", "--output", "json"]));
+    expect(res.value).toBe(0);
+    const parsed = JSON.parse(res.out) as {
+      agents: Array<{
+        name: string;
+        model: string;
+        sandboxLevel: number;
+        allowedToolsCount: number;
+      }>;
+    };
+    expect(parsed.agents).toHaveLength(1);
+    expect(parsed.agents[0]?.name).toBe("alpha");
+    expect(parsed.agents[0]?.model).toBe("sonnet");
+    expect(parsed.agents[0]?.sandboxLevel).toBe(1);
+    expect(parsed.agents[0]?.allowedToolsCount).toBe(2);
+  });
+});

--- a/tests/integration/worker-wiring.test.ts
+++ b/tests/integration/worker-wiring.test.ts
@@ -263,4 +263,27 @@ describe("worker review pipeline (opt-in)", () => {
     const events = deps.eventsRepo.queryByTaskRun(result.run.id);
     expect(events.map((e) => e.kind)).toContain("review.pipeline.exhausted");
   });
+
+  test("agente inexistente em task retorna erro claro", async () => {
+    const deps = baseDeps(testDb, mockClient);
+    const task = deps.tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "Add sum",
+      agent: "nonexistent",
+      sessionId: null,
+      workingDir: null,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+    const withResolver: RunnerDeps = {
+      ...deps,
+      resolveAgentDefinition: async () => null,
+    };
+
+    await expect(processTask(withResolver, task)).rejects.toThrow(
+      "agent 'nonexistent' not found in AGENT.md definitions",
+    );
+  });
 });

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  AgentDefinitionError,
+  loadAgentDefinition,
+  loadAllAgentDefinitions,
+  parseAgentFrontmatter,
+} from "@clawde/agents";
+
+function writeAgent(agentDir: string, frontmatter: string, body = "system prompt"): void {
+  writeFileSync(join(agentDir, "AGENT.md"), `---\n${frontmatter}\n---\n\n${body}\n`);
+}
+
+describe("agents/loader parseAgentFrontmatter", () => {
+  test("AGENT.md sem frontmatter inicial falha com erro claro", () => {
+    expect(() => parseAgentFrontmatter("# sem frontmatter")).toThrow(
+      /must start with frontmatter delimiter/,
+    );
+  });
+});
+
+describe("agents/loader loadAgentDefinition", () => {
+  const cleanups: string[] = [];
+
+  afterEach(() => {
+    for (const dir of cleanups.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("AGENT.md sem name falha com erro zod claro", () => {
+    const dir = mkdtempSync(join(tmpdir(), "clawde-agent-"));
+    cleanups.push(dir);
+    writeAgent(
+      dir,
+      [
+        'role: "role"',
+        "model: sonnet",
+        "allowedTools: [Read]",
+        "disallowedTools: []",
+        "maxTurns: 5",
+        "sandboxLevel: 1",
+        "requiresWorkspace: false",
+      ].join("\n"),
+    );
+    expect(() => loadAgentDefinition(dir)).toThrow(/invalid AGENT\.md frontmatter/);
+  });
+
+  test("carrega definição válida", () => {
+    const dir = mkdtempSync(join(tmpdir(), "clawde-agent-"));
+    cleanups.push(dir);
+    writeAgent(
+      dir,
+      [
+        "name: implementer",
+        'role: "Implementa tarefas"',
+        "model: sonnet",
+        "allowedTools: [Read, Edit, Write]",
+        "disallowedTools: [WebFetch]",
+        "maxTurns: 12",
+        "sandboxLevel: 2",
+        "requiresWorkspace: true",
+      ].join("\n"),
+      "Você implementa mudanças.",
+    );
+    writeFileSync(join(dir, "sandbox.toml"), 'level = 2\nallowed_writes = ["/workspace"]\n');
+
+    const def = loadAgentDefinition(dir);
+    expect(def.name).toBe("implementer");
+    expect(def.frontmatter.maxTurns).toBe(12);
+    expect(def.frontmatter.allowedTools).toEqual(["Read", "Edit", "Write"]);
+    expect(def.sandbox.level).toBe(2);
+    expect(def.sandbox.allowed_writes).toEqual(["/workspace"]);
+    expect(def.systemPrompt).toContain("Você implementa");
+  });
+});
+
+describe("agents/loader loadAllAgentDefinitions", () => {
+  const cleanups: string[] = [];
+
+  afterEach(() => {
+    for (const dir of cleanups.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("retorna agentes ordenados por nome", () => {
+    const root = mkdtempSync(join(tmpdir(), "clawde-agents-"));
+    cleanups.push(root);
+    const beta = join(root, "beta");
+    const alpha = join(root, "alpha");
+    mkdirSync(beta);
+    mkdirSync(alpha);
+    writeAgent(
+      beta,
+      [
+        "name: beta",
+        'role: "beta"',
+        "model: sonnet",
+        "allowedTools: [Read]",
+        "disallowedTools: []",
+        "maxTurns: 5",
+        "sandboxLevel: 1",
+        "requiresWorkspace: false",
+      ].join("\n"),
+    );
+    writeAgent(
+      alpha,
+      [
+        "name: alpha",
+        'role: "alpha"',
+        "model: sonnet",
+        "allowedTools: [Read]",
+        "disallowedTools: []",
+        "maxTurns: 5",
+        "sandboxLevel: 1",
+        "requiresWorkspace: false",
+      ].join("\n"),
+    );
+    const defs = loadAllAgentDefinitions(root);
+    expect(defs.map((d) => d.name)).toEqual(["alpha", "beta"]);
+  });
+
+  test("AGENT.md ausente lança AgentDefinitionError", () => {
+    const dir = mkdtempSync(join(tmpdir(), "clawde-agent-"));
+    cleanups.push(dir);
+    expect(() => loadAgentDefinition(dir)).toThrow(AgentDefinitionError);
+  });
+});


### PR DESCRIPTION
Closes sub-phase P2.5a in EXECUTION_BACKLOG.md.

## Tasks included
- T-063: parser caseiro de frontmatter em src/agents/loader.ts
- T-064: AgentFrontmatterSchema (zod)
- T-065: loadAgentDefinition + loadAllAgentDefinitions
- T-066: worker bootstrap carrega definições de agentes e falha com mensagem clara em inválidos
- T-067: runner consulta AGENT.md por task.agent, aplica allowedTools/disallowedTools/maxTurns e ativa gate PreToolUse
- T-068: testes de loader inválido/parse
- T-077: teste de agente inexistente em task com erro claro
- T-078: comando 

## What changed
Introduzido módulo  com parsing/validação de AGENT.md e composição com sandbox.toml. O worker agora carrega essas definições no bootstrap e usa o  para decidir policy de execução no runner (inclusive gate de tools). A CLI ganhou  para inspeção operacional.

## Acceptance criteria validated
- [x] Schema raiz de frontmatter com campos obrigatórios da P2.5a
- [x] Worker bootstrap invalida boot para AGENT.md inválido com erro explícito
- [x] Runner usa definição do agente para options do SDK e gates de tools
- [x] Testes para parse/validação e agente inexistente
- [x] Comando CLI  retornando nome/model/sandbox/contagem de tools

## CI
- [x] 
- [x] Checked 170 files in 1002ms. No fixes applied.
Found 2 warnings. (apenas 2 warnings históricos em tests bootstrap)
- [x] bun test v1.3.13 (bf2e2cec)
applied: 1, 2, 3
applied: 1, 2, 3
{
  "applied": [
    1,
    2,
    3
  ]
}
applied: 1, 2, 3
applied: 1, 2, 3
{"ts":"2026-04-30T00:27:01.931Z","level":"INFO","msg":"task processing","component":"lease-reconcile-test","taskId":1,"agent":"default","priority":"NORMAL"}
{"ts":"2026-04-30T00:27:01.934Z","level":"INFO","msg":"task finished","component":"lease-reconcile-test","taskId":1,"status":"succeeded","msgs":1}
{"ts":"2026-04-30T00:27:08.508Z","level":"INFO","msg":"task processing","component":"workspace-isolation-test","taskId":1,"agent":"implementer","priority":"NORMAL"}
{"ts":"2026-04-30T00:27:08.537Z","level":"INFO","msg":"task finished","component":"workspace-isolation-test","taskId":1,"status":"succeeded","msgs":1} (flaky histórico de lease timing permanece intermitente em suite completa)

## Notes for reviewer
Ponto crítico de P2.2 foi fechado no local do TODO (runner) com wire-up de policy por agente. Mantive  fail-safe no runner e também passei  para o SDK.

## Cross-wave dependencies
- P2.5b (T-069..T-076) vai preencher AGENT.md dos demais agentes e refinar policy por role.