### PR TITLE
fix(agents): align level with Bash availability (Wave 3 followup)

### DIFF
--- a/.claude/agents/code-quality-reviewer/AGENT.md
+++ b/.claude/agents/code-quality-reviewer/AGENT.md
@@ -2,8 +2,11 @@
 name: code-quality-reviewer
 role: "Valida qualidade não-funcional e riscos óbvios na implementação"
 model: sonnet
-allowedTools: [Read, Grep, Glob, Bash]
-disallowedTools: [Edit, Write, WebFetch, WebSearch]
+# Bash removido: em level=2 o runtime auto-disallow (P2.2 T-050 fail-safe), e
+# este agente fica fail-honest ao explicitar que é review-by-reading. Lint/format
+# pode rodar antes via verifier (level=1 com Bash). Ver ADR 0015.
+allowedTools: [Read, Grep, Glob]
+disallowedTools: [Bash, Edit, Write, WebFetch, WebSearch]
 maxTurns: 8
 sandboxLevel: 2
 requiresWorkspace: false

--- a/.claude/agents/implementer/AGENT.md
+++ b/.claude/agents/implementer/AGENT.md
@@ -5,7 +5,10 @@ model: sonnet
 allowedTools: [Read, Edit, Write, Bash, Grep, Glob]
 disallowedTools: [WebFetch, WebSearch]
 maxTurns: 15
-sandboxLevel: 2
+# sandboxLevel=1 enquanto Estratégia A (subprocess wrapper bwrap) não existir.
+# Em level >= 2 o runtime adiciona Bash ao disallowedTools (P2.2 T-050 fail-safe),
+# o que quebraria builds/testes do implementer. Ver ADR 0015.
+sandboxLevel: 1
 requiresWorkspace: true
 ---
 

--- a/.claude/agents/implementer/AGENT.md
+++ b/.claude/agents/implementer/AGENT.md
@@ -8,6 +8,8 @@ maxTurns: 15
 # sandboxLevel=1 enquanto Estratégia A (subprocess wrapper bwrap) não existir.
 # Em level >= 2 o runtime adiciona Bash ao disallowedTools (P2.2 T-050 fail-safe),
 # o que quebraria builds/testes do implementer. Ver ADR 0015.
+# Trade-off explícito: level=1 mantém risco de execução de comandos influenciados
+# por conteúdo não-confiável já presente no workspace (prompt injection em arquivos).
 sandboxLevel: 1
 requiresWorkspace: true
 ---

--- a/.claude/agents/implementer/sandbox.toml
+++ b/.claude/agents/implementer/sandbox.toml
@@ -1,4 +1,4 @@
-level = 2
+level = 1
 network = "loopback-only"
 allowed_egress = []
 allowed_writes = ["/workspace"]

--- a/.claude/agents/verifier/AGENT.md
+++ b/.claude/agents/verifier/AGENT.md
@@ -5,7 +5,10 @@ model: sonnet
 allowedTools: [Read, Bash, Grep]
 disallowedTools: [Edit, Write, WebFetch, WebSearch]
 maxTurns: 10
-sandboxLevel: 2
+# sandboxLevel=1 enquanto Estratégia A (bwrap subprocess wrapper) não existir.
+# Em level >= 2 Bash é auto-disallowed pelo runtime (P2.2 T-050), e este agente
+# precisa rodar `bun test` no workspace. Ver ADR 0015.
+sandboxLevel: 1
 requiresWorkspace: true
 ---
 

--- a/.claude/agents/verifier/AGENT.md
+++ b/.claude/agents/verifier/AGENT.md
@@ -8,6 +8,8 @@ maxTurns: 10
 # sandboxLevel=1 enquanto Estratégia A (bwrap subprocess wrapper) não existir.
 # Em level >= 2 Bash é auto-disallowed pelo runtime (P2.2 T-050), e este agente
 # precisa rodar `bun test` no workspace. Ver ADR 0015.
+# Trade-off explícito: level=1 mantém risco de execução de comandos influenciados
+# por conteúdo não-confiável já presente no workspace (prompt injection em arquivos).
 sandboxLevel: 1
 requiresWorkspace: true
 ---

--- a/.claude/agents/verifier/sandbox.toml
+++ b/.claude/agents/verifier/sandbox.toml
@@ -1,4 +1,4 @@
-level = 2
+level = 1
 network = "loopback-only"
 allowed_egress = []
 allowed_writes = ["/workspace"]

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,9 +1,11 @@
 export {
   type AgentDefinition,
+  type AgentPolicyWarning,
   type AgentFrontmatter,
   AgentDefinitionError,
   AgentFrontmatterSchema,
   loadAgentDefinition,
   loadAllAgentDefinitions,
+  loadAllAgentDefinitionsWithWarnings,
   parseAgentFrontmatter,
 } from "./loader.ts";

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -28,6 +28,13 @@ export interface AgentDefinition {
   readonly sandbox: AgentSandboxConfig;
 }
 
+export interface AgentPolicyWarning {
+  readonly kind: "bash_disallowed_by_sandbox_level";
+  readonly agentName: string;
+  readonly agentDir: string;
+  readonly sandboxLevel: number;
+}
+
 export class AgentDefinitionError extends Error {
   constructor(
     message: string,
@@ -146,6 +153,15 @@ export function loadAgentDefinition(agentDir: string): AgentDefinition {
 }
 
 export function loadAllAgentDefinitions(agentsRoot: string): ReadonlyArray<AgentDefinition> {
+  return loadAllAgentDefinitionsWithWarnings(agentsRoot);
+}
+
+export function loadAllAgentDefinitionsWithWarnings(
+  agentsRoot: string,
+  options?: {
+    readonly onWarning?: (warning: AgentPolicyWarning) => void;
+  },
+): ReadonlyArray<AgentDefinition> {
   if (!existsSync(agentsRoot)) return [];
   const defs: AgentDefinition[] = [];
   for (const entry of readdirSync(agentsRoot)) {
@@ -157,7 +173,16 @@ export function loadAllAgentDefinitions(agentsRoot: string): ReadonlyArray<Agent
       continue;
     }
     if (!stat.isDirectory()) continue;
-    defs.push(loadAgentDefinition(dir));
+    const def = loadAgentDefinition(dir);
+    if (def.frontmatter.allowedTools.includes("Bash") && def.sandbox.level >= 2) {
+      options?.onWarning?.({
+        kind: "bash_disallowed_by_sandbox_level",
+        agentName: def.name,
+        agentDir: dir,
+        sandboxLevel: def.sandbox.level,
+      });
+    }
+    defs.push(def);
   }
   defs.sort((a, b) => a.name.localeCompare(b.name));
   return defs;

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -1,6 +1,6 @@
 import { homedir, hostname } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { AgentDefinitionError, loadAllAgentDefinitions } from "@clawde/agents";
+import { AgentDefinitionError, loadAllAgentDefinitionsWithWarnings } from "@clawde/agents";
 import { loadConfig } from "@clawde/config";
 import { closeDb, openDb } from "@clawde/db/client";
 import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
@@ -75,7 +75,17 @@ export async function bootstrap(
     const agentsRoot = join(expandHome(config.clawde.home), "agents");
     const agentDefs = (() => {
       try {
-        return loadAllAgentDefinitions(agentsRoot);
+        return loadAllAgentDefinitionsWithWarnings(agentsRoot, {
+          onWarning: (warning) => {
+            if (warning.kind === "bash_disallowed_by_sandbox_level") {
+              logger.warn("agent policy mismatch: Bash will be blocked at runtime", {
+                agent: warning.agentName,
+                sandbox_level: warning.sandboxLevel,
+                hint: "Set sandbox level to 1 or remove Bash from allowedTools (ADR 0015 / T-050).",
+              });
+            }
+          },
+        });
       } catch (err) {
         if (err instanceof AgentDefinitionError) {
           const agentName = basename(dirname(err.agentPath));

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -6,6 +6,7 @@ import {
   AgentDefinitionError,
   loadAgentDefinition,
   loadAllAgentDefinitions,
+  loadAllAgentDefinitionsWithWarnings,
   parseAgentFrontmatter,
 } from "@clawde/agents";
 
@@ -123,5 +124,42 @@ describe("agents/loader loadAllAgentDefinitions", () => {
     const dir = mkdtempSync(join(tmpdir(), "clawde-agent-"));
     cleanups.push(dir);
     expect(() => loadAgentDefinition(dir)).toThrow(AgentDefinitionError);
+  });
+
+  test("emite warning quando agent declara Bash com sandbox level >= 2", () => {
+    const root = mkdtempSync(join(tmpdir(), "clawde-agents-"));
+    cleanups.push(root);
+    const impl = join(root, "implementer");
+    mkdirSync(impl);
+    writeAgent(
+      impl,
+      [
+        "name: implementer",
+        'role: "Implementa"',
+        "model: sonnet",
+        "allowedTools: [Read, Bash]",
+        "disallowedTools: []",
+        "maxTurns: 10",
+        "sandboxLevel: 2",
+        "requiresWorkspace: true",
+      ].join("\n"),
+    );
+    writeFileSync(join(impl, "sandbox.toml"), 'level = 2\nnetwork = "none"\n');
+
+    const warnings: Array<{
+      kind: string;
+      agentName: string;
+      sandboxLevel: number;
+    }> = [];
+    const defs = loadAllAgentDefinitionsWithWarnings(root, {
+      onWarning: (warning) => warnings.push(warning),
+    });
+    expect(defs).toHaveLength(1);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      kind: "bash_disallowed_by_sandbox_level",
+      agentName: "implementer",
+      sandboxLevel: 2,
+    });
   });
 });


### PR DESCRIPTION
Resolves the design tension flagged in [PR #12 review](https://github.com/Incavenuziano/Clawde/pull/12#issuecomment-4348843505) (Alerta 2 — `level=2 + Bash` conflicting with runtime).

## Problem

P2.5b created agent profiles per spec literal:
- T-070 implementer: `level=2 + Bash`
- T-072 code-quality-reviewer: `level=2 + Bash`
- T-073 verifier: `level=2 + Bash`

But P2.2 T-050 (and the wire-up in P2.5a `runner.ts:398-400`) auto-disallow `Bash` at `sandbox.level >= 2` as fail-safe, since Estratégia A (bwrap subprocess wrapper) is deferred.

Result before this fix: implementer can't run builds, verifier can't run `bun test`, code-quality-reviewer can't run lint. Specs are aspirational, runtime blocks.

## Approach (Opção D do review)

Hybrid: lower level for agents that NEED Bash, keep level=2 for agents that don't really need it (and gain stronger isolation).

| Agent | Before | After | Rationale |
|-------|--------|-------|-----------|
| implementer | level=2 + Bash | level=1 + Bash | Needs build/test commands; runs at worker-process hardening. |
| verifier | level=2 + Bash | level=1 + Bash | Needs `bun test`; same as above. |
| code-quality-reviewer | level=2 + Bash | level=2 (Bash removed) | Fail-honest: review-by-reading, gains real level=2 isolation, lint runs upstream via verifier. |

Each frontmatter has an inline comment referencing P2.2 T-050 and ADR 0015 so the next reader understands why level=1.

## Threat model justification for level=1

- implementer/verifier are invoked only from `cli` (operator) or trusted subagents. External input sources (telegram, webhook) target level=3 read-only profiles (telegram-bot, github-pr-handler), not these.
- Bash at level=1 runs in the worker process which has systemd hardening (level 1). Acceptable for trusted callers.
- Untrusted input never reaches implementer/verifier directly.

## Acceptance

- [x] implementer/verifier sandboxLevel=1 + sandbox.toml level=1
- [x] code-quality-reviewer keeps level=2, removes Bash from allowedTools, adds to disallowedTools
- [x] Inline comments document the deviation
- [x] Existing tests pass (no logic change)

## CI

- bun run typecheck ✅
- bun run lint ✅
- bun test 605/606 (1 flaky histórico)

## Out of scope (Wave 4+)

- Estratégia A (bwrap subprocess wrapper) — would re-enable level=2/3 with functional Bash. Tracked as architectural debt.
- Read-path policy in PreToolUse handler (Alerta 1 do review #12) — separate followup, depends on operator confirming Telegram auto-response semantics.

🤖 Followup by Claude Sonnet 4.6