### PR TITLE
P1.4: EventKind CHECK constraint + migration + tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -44,7 +44,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P2.4 | `task/P2.4-review-fresh` | T-058..T-062 | claude | codex | pending | — |
 | P2.5a | `task/P2.5a-agent-loader` | T-063..T-068, T-077, T-078 | codex | claude | merged, PR #11, 2026-04-30 | #11 |
 | P2.5b | `task/P2.5b-agent-files` | T-069..T-076 | codex | claude (+ operador em T-075/076) | merged, PR #12, 2026-04-30 | #12 |
-| P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | pending | — |
+| P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | in-review, codex | — |
 | P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | pending | — |
 | P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | pending | — |
 | P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | pending | — |
@@ -182,13 +182,13 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 ## Wave 4 — Hardening (P1.4, P1.5, P2.6, P2.7)
 
 ### P1.4 — EventKind CHECK constraint
-- [ ] T-079 — pending
-- [ ] T-080 — pending
-- [ ] T-081 — pending
-- [ ] T-082 — pending
-- [ ] T-083 — pending
-- [ ] T-084 — pending
-- [ ] T-085 — pending
+- [x] T-079 — done on branch `task/P1.4-event-kind` (docs/event-kinds-audit.md)
+- [x] T-080 — done on branch `task/P1.4-event-kind` (EventKind/EventKind values audit-sync)
+- [x] T-081 — done on branch `task/P1.4-event-kind` (migration 004_event_kind_check)
+- [x] T-082 — done on branch `task/P1.4-event-kind` (filtered copy + fail-fast if invalid >5)
+- [x] T-083 — done on branch `task/P1.4-event-kind` (recreated indexes + append-only triggers)
+- [x] T-084 — done on branch `task/P1.4-event-kind` (unit test invalid kind)
+- [x] T-085 — done on branch `task/P1.4-event-kind` (property roundtrip over EVENT_KIND_VALUES)
 
 ### P1.5 — JSON validity em colunas TEXT
 - [ ] T-086 — pending

--- a/docs/event-kinds-audit.md
+++ b/docs/event-kinds-audit.md
@@ -1,0 +1,42 @@
+# Event Kinds Audit (T-079)
+
+Date: 2026-04-29
+Branch: `task/P1.4-event-kind`
+
+## Método
+
+- Busca por emissores reais de evento: `eventsRepo.insert(...)` em `src/`.
+- Checagem do union canônico em `src/domain/event.ts` (`EVENT_KIND_VALUES`).
+
+## Kinds emitidos em runtime (grep de callers)
+
+- `enqueue`
+- `rate_limit_hit`
+- `dedup_skip`
+- `auth.telegram_reject`
+- `auth.telegram_user_blocked`
+- `task_start`
+- `task_finish`
+- `task_fail`
+- `task_deferred`
+- `lease_expired`
+- `claude_invocation_start`
+- `claude_invocation_end`
+- `quota_429_observed`
+- `sdk_auth_error`
+- `review.implementer.end`
+- `review.spec.verdict`
+- `review.quality.verdict`
+- `review.pipeline.complete`
+- `review.pipeline.exhausted`
+- `agent_invalid`
+
+## Comparação com `EVENT_KIND_VALUES`
+
+Resultado: todos os kinds emitidos acima já existem no union canônico
+`EventKind`/`EVENT_KIND_VALUES`.
+
+Observação: o union contém kinds adicionais suportados por contrato de domínio
+(por ex. `tool_use`, `tool_result`, `tool_blocked`, `sandbox_*`, `quota_*`,
+`hook_*`, `lesson`, `reflection_*`) que podem não ser emitidos por todos os
+fluxos no estado atual do código.

--- a/src/db/migrations/004_event_kind_check.down.sql
+++ b/src/db/migrations/004_event_kind_check.down.sql
@@ -1,0 +1,33 @@
+-- Migration 004 (DOWN) — remove EventKind/json_valid checks from events table.
+
+CREATE TABLE events_old (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           TEXT    NOT NULL DEFAULT (datetime('now')),
+  task_run_id  INTEGER REFERENCES task_runs(id) ON DELETE SET NULL,
+  session_id   TEXT    REFERENCES sessions(session_id) ON DELETE SET NULL,
+  trace_id     TEXT,
+  span_id      TEXT,
+  kind         TEXT    NOT NULL,
+  payload      TEXT    NOT NULL DEFAULT '{}'
+);
+
+INSERT INTO events_old SELECT * FROM events;
+DROP TABLE events;
+ALTER TABLE events_old RENAME TO events;
+
+CREATE INDEX idx_events_task_ts ON events(task_run_id, ts);
+CREATE INDEX idx_events_trace ON events(trace_id) WHERE trace_id IS NOT NULL;
+CREATE INDEX idx_events_kind_ts ON events(kind, ts);
+
+CREATE TRIGGER events_no_update
+BEFORE UPDATE ON events
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only');
+END;
+
+CREATE TRIGGER events_no_delete
+BEFORE DELETE ON events
+WHEN (SELECT COUNT(*) FROM _retention_grant) = 0
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only outside retention job');
+END;

--- a/src/db/migrations/004_event_kind_check.up.sql
+++ b/src/db/migrations/004_event_kind_check.up.sql
@@ -1,0 +1,209 @@
+-- Migration 004 (UP) — enforce EventKind whitelist + payload JSON validity.
+-- P1.4 (T-081..T-083): recria events com CHECK(kind IN ...) e CHECK(json_valid(payload)).
+
+CREATE TABLE events_new (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           TEXT    NOT NULL DEFAULT (datetime('now')),
+  task_run_id  INTEGER REFERENCES task_runs(id) ON DELETE SET NULL,
+  session_id   TEXT    REFERENCES sessions(session_id) ON DELETE SET NULL,
+  trace_id     TEXT,
+  span_id      TEXT,
+  kind         TEXT    NOT NULL
+               CHECK (kind IN (
+                 'enqueue',
+                 'auth_fail',
+                 'rate_limit_hit',
+                 'dedup_skip',
+                 'task_deferred',
+                 'task_start',
+                 'task_finish',
+                 'task_fail',
+                 'lease_expired',
+                 'quarantine_enter',
+                 'quarantine_exit',
+                 'claude_invocation_start',
+                 'claude_invocation_end',
+                 'tool_use',
+                 'tool_result',
+                 'tool_blocked',
+                 'compact_triggered',
+                 'quota_threshold_crossed',
+                 'quota_reset',
+                 'peak_multiplier_applied',
+                 'quota_429_observed',
+                 'oauth_refresh_attempt',
+                 'oauth_refresh_success',
+                 'oauth_expiry_warning',
+                 'auth.telegram_reject',
+                 'auth.telegram_user_blocked',
+                 'sandbox_init',
+                 'sandbox_violation',
+                 'migration_start',
+                 'migration_end',
+                 'migration_fail',
+                 'maintenance_start',
+                 'maintenance_end',
+                 'prompt_guard_alert',
+                 'panic_stop',
+                 'hook_error',
+                 'hook_timeout',
+                 'lesson',
+                 'reflection_start',
+                 'reflection_end',
+                 'review.implementer.start',
+                 'review.implementer.end',
+                 'review.spec.start',
+                 'review.spec.verdict',
+                 'review.quality.start',
+                 'review.quality.verdict',
+                 'review.pipeline.complete',
+                 'review.pipeline.exhausted',
+                 'agent_invalid',
+                 'sdk_auth_error',
+                 'sdk_network_error'
+               )),
+  payload      TEXT    NOT NULL DEFAULT '{}'
+               CHECK (json_valid(payload))
+);
+
+-- Fail-fast se houver muitos kinds inválidos no legado (sinal de corrupção).
+-- Até 5 rows inválidas são descartadas no copy (melhor esforço para upgrade).
+CREATE TABLE _migration_004_guard (
+  invalid_kind_rows INTEGER NOT NULL CHECK (invalid_kind_rows <= 5)
+);
+
+INSERT INTO _migration_004_guard (invalid_kind_rows)
+SELECT COUNT(*)
+FROM events
+WHERE kind NOT IN (
+  'enqueue',
+  'auth_fail',
+  'rate_limit_hit',
+  'dedup_skip',
+  'task_deferred',
+  'task_start',
+  'task_finish',
+  'task_fail',
+  'lease_expired',
+  'quarantine_enter',
+  'quarantine_exit',
+  'claude_invocation_start',
+  'claude_invocation_end',
+  'tool_use',
+  'tool_result',
+  'tool_blocked',
+  'compact_triggered',
+  'quota_threshold_crossed',
+  'quota_reset',
+  'peak_multiplier_applied',
+  'quota_429_observed',
+  'oauth_refresh_attempt',
+  'oauth_refresh_success',
+  'oauth_expiry_warning',
+  'auth.telegram_reject',
+  'auth.telegram_user_blocked',
+  'sandbox_init',
+  'sandbox_violation',
+  'migration_start',
+  'migration_end',
+  'migration_fail',
+  'maintenance_start',
+  'maintenance_end',
+  'prompt_guard_alert',
+  'panic_stop',
+  'hook_error',
+  'hook_timeout',
+  'lesson',
+  'reflection_start',
+  'reflection_end',
+  'review.implementer.start',
+  'review.implementer.end',
+  'review.spec.start',
+  'review.spec.verdict',
+  'review.quality.start',
+  'review.quality.verdict',
+  'review.pipeline.complete',
+  'review.pipeline.exhausted',
+  'agent_invalid',
+  'sdk_auth_error',
+  'sdk_network_error'
+);
+
+INSERT INTO events_new
+SELECT *
+FROM events
+WHERE kind IN (
+  'enqueue',
+  'auth_fail',
+  'rate_limit_hit',
+  'dedup_skip',
+  'task_deferred',
+  'task_start',
+  'task_finish',
+  'task_fail',
+  'lease_expired',
+  'quarantine_enter',
+  'quarantine_exit',
+  'claude_invocation_start',
+  'claude_invocation_end',
+  'tool_use',
+  'tool_result',
+  'tool_blocked',
+  'compact_triggered',
+  'quota_threshold_crossed',
+  'quota_reset',
+  'peak_multiplier_applied',
+  'quota_429_observed',
+  'oauth_refresh_attempt',
+  'oauth_refresh_success',
+  'oauth_expiry_warning',
+  'auth.telegram_reject',
+  'auth.telegram_user_blocked',
+  'sandbox_init',
+  'sandbox_violation',
+  'migration_start',
+  'migration_end',
+  'migration_fail',
+  'maintenance_start',
+  'maintenance_end',
+  'prompt_guard_alert',
+  'panic_stop',
+  'hook_error',
+  'hook_timeout',
+  'lesson',
+  'reflection_start',
+  'reflection_end',
+  'review.implementer.start',
+  'review.implementer.end',
+  'review.spec.start',
+  'review.spec.verdict',
+  'review.quality.start',
+  'review.quality.verdict',
+  'review.pipeline.complete',
+  'review.pipeline.exhausted',
+  'agent_invalid',
+  'sdk_auth_error',
+  'sdk_network_error'
+);
+
+DROP TABLE events;
+ALTER TABLE events_new RENAME TO events;
+
+CREATE INDEX idx_events_task_ts ON events(task_run_id, ts);
+CREATE INDEX idx_events_trace ON events(trace_id) WHERE trace_id IS NOT NULL;
+CREATE INDEX idx_events_kind_ts ON events(kind, ts);
+
+CREATE TRIGGER events_no_update
+BEFORE UPDATE ON events
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only');
+END;
+
+CREATE TRIGGER events_no_delete
+BEFORE DELETE ON events
+WHEN (SELECT COUNT(*) FROM _retention_grant) = 0
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only outside retention job');
+END;
+
+DROP TABLE _migration_004_guard;

--- a/tests/property/event-kind-roundtrip.test.ts
+++ b/tests/property/event-kind-roundtrip.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EventsRepo } from "@clawde/db/repositories/events";
+import { EVENT_KIND_VALUES } from "@clawde/domain/event";
+import { type TestDb, makeTestDb } from "../helpers/db.ts";
+
+describe("property: EventKind roundtrip", () => {
+  let testDb: TestDb;
+  let repo: EventsRepo;
+
+  beforeEach(() => {
+    testDb = makeTestDb();
+    repo = new EventsRepo(testDb.db);
+  });
+
+  afterEach(() => {
+    testDb.cleanup();
+  });
+
+  test("every EVENT_KIND_VALUE inserts and reads back", () => {
+    for (const kind of EVENT_KIND_VALUES) {
+      const inserted = repo.insert({
+        taskRunId: null,
+        sessionId: null,
+        traceId: null,
+        spanId: null,
+        kind,
+        payload: { probe: kind },
+      });
+      expect(inserted.kind).toBe(kind);
+      expect(inserted.payload).toEqual({ probe: kind });
+    }
+  });
+});

--- a/tests/unit/db/event-kind-check.test.ts
+++ b/tests/unit/db/event-kind-check.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type TestDb, makeTestDb } from "../../helpers/db.ts";
+
+describe("db/events kind CHECK constraint", () => {
+  let testDb: TestDb;
+
+  beforeEach(() => {
+    testDb = makeTestDb();
+  });
+
+  afterEach(() => {
+    testDb.cleanup();
+  });
+
+  test("rejects invalid events.kind values", () => {
+    expect(() =>
+      testDb.db.exec(`
+        INSERT INTO events (kind, payload)
+        VALUES ('typo_kind', '{}')
+      `),
+    ).toThrow(/CHECK constraint failed/);
+  });
+});


### PR DESCRIPTION
Closes sub-phase P1.4 in EXECUTION_BACKLOG.md.

## Tasks included
- T-079: audit dos event kinds emitidos
- T-080: alinhamento de EventKind/EVENT_KIND_VALUES
- T-081: migration para CHECK kind + json_valid(payload) em events
- T-082: validação/cópia filtrada + fail-fast quando inválidos > 5
- T-083: recriação explícita de índices e triggers append-only
- T-084: teste de kind inválido falha por CHECK
- T-085: teste de roundtrip para todos EVENT_KIND_VALUES

## What changed
Adiciona auditoria de kinds emitidos em runtime e uma migration nova que recria a tabela events com constraints de integridade para kind e payload JSON. A migration preserva dados válidos, falha em cenário de corrupção relevante e recria índices/triggers necessários. Também adiciona testes unit/property para garantir que a restrição funciona e permanece sincronizada com o domínio.

## Acceptance criteria validated
- [x] T-079 criteria
- [x] T-080 criteria
- [x] T-081 criteria
- [x] T-082 criteria
- [x] T-083 criteria
- [x] T-084 criteria
- [x] T-085 criteria

## CI
- [ ] bun run typecheck clean (bloqueado por issue de ambiente/TS5101 pré-existente)
- [x] bun run lint clean (2 warnings preexistentes em testes bootstrap)
- [x] bun test passing

## Notes for reviewer
- Migração adicionada: 004_event_kind_check (up/down).
- Fail-fast da migration dispara quando existem >5 rows com kind inválido na tabela legacy events.
- Inserção em events com kind inválido agora falha por CHECK.

## Cross-wave dependencies
- Nenhuma.

Implemented by Codex