### PR TITLE
P1.5: JSON validity checks + corruption-safe parsing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -45,7 +45,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P2.5a | `task/P2.5a-agent-loader` | T-063..T-068, T-077, T-078 | codex | claude | merged, PR #11, 2026-04-30 | #11 |
 | P2.5b | `task/P2.5b-agent-files` | T-069..T-076 | codex | claude (+ operador em T-075/076) | merged, PR #12, 2026-04-30 | #12 |
 | P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | merged, PR #17, 2026-04-30 | #17 |
-| P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | in-progress, codex | — |
+| P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | in-review, PR #19 | #19 |
 | P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | pending | — |
 | P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | pending | — |
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | pending | — |
@@ -191,12 +191,12 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-085 — merged, PR #17, 2026-04-30
 
 ### P1.5 — JSON validity em colunas TEXT
-- [ ] T-086 — in-progress, codex
-- [ ] T-087 — pending
-- [ ] T-088 — pending
-- [ ] T-089 — pending
-- [ ] T-090 — pending
-- [ ] T-091 — pending
+- [x] T-086 — in-review, PR #19
+- [x] T-087 — in-review, PR #19
+- [x] T-088 — in-review, PR #19
+- [x] T-089 — in-review, PR #19
+- [x] T-090 — in-review, PR #19
+- [x] T-091 — in-review, PR #19
 
 ### P2.6 — Allowlist falsa
 - [ ] T-092 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -45,7 +45,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P2.5a | `task/P2.5a-agent-loader` | T-063..T-068, T-077, T-078 | codex | claude | merged, PR #11, 2026-04-30 | #11 |
 | P2.5b | `task/P2.5b-agent-files` | T-069..T-076 | codex | claude (+ operador em T-075/076) | merged, PR #12, 2026-04-30 | #12 |
 | P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | merged, PR #17, 2026-04-30 | #17 |
-| P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | pending | — |
+| P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | in-progress, codex | — |
 | P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | pending | — |
 | P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | pending | — |
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | pending | — |
@@ -191,7 +191,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-085 — merged, PR #17, 2026-04-30
 
 ### P1.5 — JSON validity em colunas TEXT
-- [ ] T-086 — pending
+- [ ] T-086 — in-progress, codex
 - [ ] T-087 — pending
 - [ ] T-088 — pending
 - [ ] T-089 — pending

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -13,6 +13,7 @@
 
 import { type ClawdeDatabase, closeDb, openDb } from "@clawde/db/client";
 import { EventsRepo } from "@clawde/db/repositories/events";
+import type { JsonCorruptionError } from "@clawde/db/repositories/tasks";
 import type { Event, EventKind } from "@clawde/domain/event";
 import { type OutputFormat, emit, emitErr } from "../output.ts";
 
@@ -63,13 +64,18 @@ export function runLogs(options: LogsOptions): number {
   try {
     const repo = new EventsRepo(db);
     let events: ReadonlyArray<Event> = [];
+    let corruptedRows = 0;
+    const onCorruption = (error: JsonCorruptionError): void => {
+      corruptedRows += 1;
+      emitErr(`WARN: row ${error.rowId} corrupted (column ${error.column}); skipping`);
+    };
 
     if (options.taskRunId !== undefined) {
-      events = repo.queryByTaskRun(options.taskRunId);
+      events = repo.queryByTaskRun(options.taskRunId, { onCorruption });
     } else if (options.traceId !== undefined) {
-      events = repo.queryByTrace(options.traceId);
+      events = repo.queryByTrace(options.traceId, { onCorruption });
     } else if (options.kind !== undefined) {
-      events = repo.queryByKind(options.kind, options.limit);
+      events = repo.queryByKind(options.kind, options.limit, { onCorruption });
     } else if (options.since !== undefined) {
       const ms = parseSinceToMs(options.since);
       if (ms === null) {
@@ -77,31 +83,7 @@ export function runLogs(options: LogsOptions): number {
         return 1;
       }
       const cutoff = new Date(Date.now() - ms).toISOString();
-      events = db
-        .query<
-          {
-            id: number;
-            ts: string;
-            task_run_id: number | null;
-            session_id: string | null;
-            trace_id: string | null;
-            span_id: string | null;
-            kind: EventKind;
-            payload: string;
-          },
-          [string, number]
-        >("SELECT * FROM events WHERE ts >= ? ORDER BY ts DESC LIMIT ?")
-        .all(cutoff, options.limit)
-        .map((r) => ({
-          id: r.id,
-          ts: r.ts,
-          taskRunId: r.task_run_id,
-          sessionId: r.session_id,
-          traceId: r.trace_id,
-          spanId: r.span_id,
-          kind: r.kind,
-          payload: JSON.parse(r.payload) as Record<string, unknown>,
-        }));
+      events = repo.querySince(cutoff, options.limit, { onCorruption });
     } else {
       emitErr("error: at least one of --task, --trace, --since, --kind required");
       return 1;
@@ -109,7 +91,10 @@ export function runLogs(options: LogsOptions): number {
 
     emit(options.format, events, (d) => {
       const list = d as ReadonlyArray<Event>;
-      if (list.length === 0) return "(no events)";
+      if (list.length === 0) {
+        if (corruptedRows > 0) return "(no events; all matching rows were corrupted)";
+        return "(no events)";
+      }
       return list.map(renderEventLine).join("\n");
     });
     return 0;

--- a/src/db/migrations/005_tasks_json_check.down.sql
+++ b/src/db/migrations/005_tasks_json_check.down.sql
@@ -1,0 +1,36 @@
+-- Migration 005 (DOWN) — remove json_valid checks from tasks JSON text columns.
+
+CREATE TABLE tasks_old (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  priority        TEXT    NOT NULL DEFAULT 'NORMAL'
+                  CHECK (priority IN ('LOW', 'NORMAL', 'HIGH', 'URGENT')),
+  prompt          TEXT    NOT NULL,
+  agent           TEXT    NOT NULL DEFAULT 'default',
+  session_id      TEXT,
+  working_dir     TEXT,
+  depends_on      TEXT    NOT NULL DEFAULT '[]',
+  source          TEXT    NOT NULL
+                  CHECK (source IN (
+                    'cli', 'telegram', 'webhook-github', 'webhook-generic',
+                    'cron', 'subagent'
+                  )),
+  source_metadata TEXT    NOT NULL DEFAULT '{}',
+  dedup_key       TEXT    UNIQUE,
+  created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO tasks_old
+SELECT *
+FROM tasks;
+
+DROP TABLE tasks;
+ALTER TABLE tasks_old RENAME TO tasks;
+
+CREATE INDEX idx_tasks_priority_created ON tasks(priority, created_at);
+CREATE INDEX idx_tasks_session ON tasks(session_id) WHERE session_id IS NOT NULL;
+
+CREATE TRIGGER tasks_no_update
+BEFORE UPDATE ON tasks
+BEGIN
+  SELECT RAISE(FAIL, 'tasks is immutable after INSERT (ADR 0007)');
+END;

--- a/src/db/migrations/005_tasks_json_check.up.sql
+++ b/src/db/migrations/005_tasks_json_check.up.sql
@@ -1,0 +1,39 @@
+-- Migration 005 (UP) — enforce json_valid checks on tasks JSON text columns.
+-- P1.5 (T-086/T-087): depends_on + source_metadata.
+
+CREATE TABLE tasks_new (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  priority        TEXT    NOT NULL DEFAULT 'NORMAL'
+                  CHECK (priority IN ('LOW', 'NORMAL', 'HIGH', 'URGENT')),
+  prompt          TEXT    NOT NULL,
+  agent           TEXT    NOT NULL DEFAULT 'default',
+  session_id      TEXT,
+  working_dir     TEXT,
+  depends_on      TEXT    NOT NULL DEFAULT '[]'
+                  CHECK (json_valid(depends_on)),
+  source          TEXT    NOT NULL
+                  CHECK (source IN (
+                    'cli', 'telegram', 'webhook-github', 'webhook-generic',
+                    'cron', 'subagent'
+                  )),
+  source_metadata TEXT    NOT NULL DEFAULT '{}'
+                  CHECK (json_valid(source_metadata)),
+  dedup_key       TEXT    UNIQUE,
+  created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO tasks_new
+SELECT *
+FROM tasks;
+
+DROP TABLE tasks;
+ALTER TABLE tasks_new RENAME TO tasks;
+
+CREATE INDEX idx_tasks_priority_created ON tasks(priority, created_at);
+CREATE INDEX idx_tasks_session ON tasks(session_id) WHERE session_id IS NOT NULL;
+
+CREATE TRIGGER tasks_no_update
+BEFORE UPDATE ON tasks
+BEGIN
+  SELECT RAISE(FAIL, 'tasks is immutable after INSERT (ADR 0007)');
+END;

--- a/src/db/repositories/events.ts
+++ b/src/db/repositories/events.ts
@@ -6,6 +6,7 @@
 
 import type { Event, EventKind, NewEvent } from "@clawde/domain/event";
 import type { ClawdeDatabase } from "../client.ts";
+import { JsonCorruptionError } from "./tasks.ts";
 
 interface RawEventRow {
   id: number;
@@ -19,6 +20,12 @@ interface RawEventRow {
 }
 
 function rowToEvent(r: RawEventRow): Event {
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(r.payload) as Record<string, unknown>;
+  } catch (error) {
+    throw new JsonCorruptionError(r.id, "payload", r.payload, { cause: error });
+  }
   return {
     id: r.id,
     ts: r.ts,
@@ -27,8 +34,31 @@ function rowToEvent(r: RawEventRow): Event {
     traceId: r.trace_id,
     spanId: r.span_id,
     kind: r.kind,
-    payload: JSON.parse(r.payload) as Record<string, unknown>,
+    payload,
   };
+}
+
+export interface QueryEventsOptions {
+  readonly onCorruption?: (error: JsonCorruptionError) => void;
+}
+
+function mapEvents(
+  rows: ReadonlyArray<RawEventRow>,
+  options?: QueryEventsOptions,
+): ReadonlyArray<Event> {
+  const events: Event[] = [];
+  for (const row of rows) {
+    try {
+      events.push(rowToEvent(row));
+    } catch (error) {
+      if (error instanceof JsonCorruptionError && options?.onCorruption !== undefined) {
+        options.onCorruption(error);
+        continue;
+      }
+      throw error;
+    }
+  }
+  return events;
 }
 
 export class EventsRepo {
@@ -61,26 +91,35 @@ export class EventsRepo {
     return rowToEvent(row);
   }
 
-  queryByTaskRun(taskRunId: number): ReadonlyArray<Event> {
+  queryByTaskRun(taskRunId: number, options?: QueryEventsOptions): ReadonlyArray<Event> {
     const rows = this.db
       .query<RawEventRow, [number]>("SELECT * FROM events WHERE task_run_id = ? ORDER BY ts, id")
       .all(taskRunId);
-    return rows.map(rowToEvent);
+    return mapEvents(rows, options);
   }
 
-  queryByTrace(traceId: string): ReadonlyArray<Event> {
+  queryByTrace(traceId: string, options?: QueryEventsOptions): ReadonlyArray<Event> {
     const rows = this.db
       .query<RawEventRow, [string]>("SELECT * FROM events WHERE trace_id = ? ORDER BY ts, id")
       .all(traceId);
-    return rows.map(rowToEvent);
+    return mapEvents(rows, options);
   }
 
-  queryByKind(kind: EventKind, limit = 100): ReadonlyArray<Event> {
+  queryByKind(kind: EventKind, limit = 100, options?: QueryEventsOptions): ReadonlyArray<Event> {
     const rows = this.db
       .query<RawEventRow, [EventKind, number]>(
         "SELECT * FROM events WHERE kind = ? ORDER BY ts DESC LIMIT ?",
       )
       .all(kind, limit);
-    return rows.map(rowToEvent);
+    return mapEvents(rows, options);
+  }
+
+  querySince(cutoffIso: string, limit = 100, options?: QueryEventsOptions): ReadonlyArray<Event> {
+    const rows = this.db
+      .query<RawEventRow, [string, number]>(
+        "SELECT * FROM events WHERE ts >= ? ORDER BY ts DESC LIMIT ?",
+      )
+      .all(cutoffIso, limit);
+    return mapEvents(rows, options);
   }
 }

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -13,6 +13,18 @@ export class DedupConflictError extends Error {
   }
 }
 
+export class JsonCorruptionError extends Error {
+  constructor(
+    public readonly rowId: number,
+    public readonly column: "depends_on" | "source_metadata" | "payload",
+    public readonly rawValue: string,
+    options?: { cause?: unknown },
+  ) {
+    super(`row ${rowId} has invalid JSON in column '${column}'`, options);
+    this.name = "JsonCorruptionError";
+  }
+}
+
 interface RawTaskRow {
   id: number;
   priority: Priority;
@@ -28,6 +40,20 @@ interface RawTaskRow {
 }
 
 function rowToTask(row: RawTaskRow): Task {
+  let dependsOn: ReadonlyArray<number>;
+  try {
+    dependsOn = JSON.parse(row.depends_on) as ReadonlyArray<number>;
+  } catch (error) {
+    throw new JsonCorruptionError(row.id, "depends_on", row.depends_on, { cause: error });
+  }
+
+  let sourceMetadata: Record<string, unknown>;
+  try {
+    sourceMetadata = JSON.parse(row.source_metadata) as Record<string, unknown>;
+  } catch (error) {
+    throw new JsonCorruptionError(row.id, "source_metadata", row.source_metadata, { cause: error });
+  }
+
   return {
     id: row.id,
     priority: row.priority,
@@ -35,9 +61,9 @@ function rowToTask(row: RawTaskRow): Task {
     agent: row.agent,
     sessionId: row.session_id,
     workingDir: row.working_dir,
-    dependsOn: JSON.parse(row.depends_on) as ReadonlyArray<number>,
+    dependsOn,
     source: row.source,
-    sourceMetadata: JSON.parse(row.source_metadata) as Record<string, unknown>,
+    sourceMetadata,
     dedupKey: row.dedup_key,
     createdAt: row.created_at,
   };

--- a/tests/integration/cli-logs-trace-quota.test.ts
+++ b/tests/integration/cli-logs-trace-quota.test.ts
@@ -189,6 +189,22 @@ describe("cli logs", () => {
     expect(exit).toBe(1);
     expect(stderr).toContain("invalid --since");
   });
+
+  test("rows corrompidas em payload geram WARN e comando segue com exit 0", async () => {
+    setup.db.exec("PRAGMA ignore_check_constraints = ON");
+    setup.db.exec(`
+      INSERT INTO events (trace_id, kind, payload)
+      VALUES ('T-CORRUPT', 'enqueue', '{bad-json')
+    `);
+    setup.db.exec("PRAGMA ignore_check_constraints = OFF");
+
+    const { exit, stderr } = await captureOutput(() =>
+      runMain(["logs", "--trace", "T-CORRUPT", "--db", setup.dbPath]),
+    );
+    expect(exit).toBe(0);
+    expect(stderr).toContain("WARN: row ");
+    expect(stderr).toContain("corrupted (column payload); skipping");
+  });
 });
 
 describe("cli trace", () => {

--- a/tests/unit/db/events.repo.test.ts
+++ b/tests/unit/db/events.repo.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { EventsRepo } from "@clawde/db/repositories/events";
+import { JsonCorruptionError } from "@clawde/db/repositories/tasks";
 import type { NewEvent } from "@clawde/domain/event";
 import { type TestDb, makeTestDb } from "../../helpers/db.ts";
 
@@ -106,5 +107,37 @@ describe("repositories/events", () => {
       input: { command: "ls -la" },
       metadata: { sandbox: 2 },
     });
+  });
+
+  test("queryByTrace lança JsonCorruptionError quando payload está inválido", () => {
+    testDb.db.exec("PRAGMA ignore_check_constraints = ON");
+    testDb.db.exec(`
+      INSERT INTO events (trace_id, kind, payload)
+      VALUES ('t-corrupt', 'enqueue', '{bad-json')
+    `);
+    testDb.db.exec("PRAGMA ignore_check_constraints = OFF");
+
+    expect(() => repo.queryByTrace("t-corrupt")).toThrow(JsonCorruptionError);
+  });
+
+  test("queryByTrace com onCorruption ignora rows inválidas e continua", () => {
+    testDb.db.exec("PRAGMA ignore_check_constraints = ON");
+    testDb.db.exec(`
+      INSERT INTO events (trace_id, kind, payload)
+      VALUES ('t-skip', 'enqueue', '{bad-json')
+    `);
+    testDb.db.exec("PRAGMA ignore_check_constraints = OFF");
+    repo.insert(sample({ traceId: "t-skip", kind: "task_start", payload: { ok: true } }));
+
+    const warnings: JsonCorruptionError[] = [];
+    const events = repo.queryByTrace("t-skip", {
+      onCorruption: (error) => {
+        warnings.push(error);
+      },
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.column).toBe("payload");
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("task_start");
   });
 });

--- a/tests/unit/db/tasks.repo.test.ts
+++ b/tests/unit/db/tasks.repo.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { DedupConflictError, TasksRepo } from "@clawde/db/repositories/tasks";
+import { DedupConflictError, JsonCorruptionError, TasksRepo } from "@clawde/db/repositories/tasks";
 import type { NewTask } from "@clawde/domain/task";
 import { type TestDb, makeTestDb } from "../../helpers/db.ts";
 
@@ -134,5 +134,47 @@ describe("repositories/tasks", () => {
   test("insert com priority URGENT é aceito", () => {
     const t = repo.insert(sampleTask({ priority: "URGENT" }));
     expect(t.priority).toBe("URGENT");
+  });
+
+  test("findById lança JsonCorruptionError quando depends_on está corrompido", () => {
+    testDb.db.exec("PRAGMA ignore_check_constraints = ON");
+    testDb.db.exec(`
+      INSERT INTO tasks (priority, prompt, agent, depends_on, source, source_metadata)
+      VALUES ('NORMAL', 'p', 'default', '{not-json', 'cli', '{}')
+    `);
+    const id = (testDb.db.query("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
+    testDb.db.exec("PRAGMA ignore_check_constraints = OFF");
+
+    try {
+      repo.findById(id);
+      throw new Error("expected JsonCorruptionError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(JsonCorruptionError);
+      const typed = error as JsonCorruptionError;
+      expect(typed.rowId).toBe(id);
+      expect(typed.column).toBe("depends_on");
+      expect(typed.rawValue).toBe("{not-json");
+    }
+  });
+
+  test("findById lança JsonCorruptionError quando source_metadata está corrompido", () => {
+    testDb.db.exec("PRAGMA ignore_check_constraints = ON");
+    testDb.db.exec(`
+      INSERT INTO tasks (priority, prompt, agent, depends_on, source, source_metadata)
+      VALUES ('NORMAL', 'p', 'default', '[]', 'cli', '{oops')
+    `);
+    const id = (testDb.db.query("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
+    testDb.db.exec("PRAGMA ignore_check_constraints = OFF");
+
+    try {
+      repo.findById(id);
+      throw new Error("expected JsonCorruptionError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(JsonCorruptionError);
+      const typed = error as JsonCorruptionError;
+      expect(typed.rowId).toBe(id);
+      expect(typed.column).toBe("source_metadata");
+      expect(typed.rawValue).toBe("{oops");
+    }
   });
 });


### PR DESCRIPTION
Closes sub-phase P1.5 in EXECUTION_BACKLOG.md.

## Tasks included
- T-086: migration 005 adiciona CHECK json_valid em tasks.depends_on
- T-087: migration 005 adiciona CHECK json_valid em tasks.source_metadata
- T-088: JsonCorruptionError tipado em repositories/tasks.ts
- T-089: rowToTask protegido com try/catch por coluna JSON
- T-090: repositories/events.ts protegido para payload JSON corrompido
- T-091: CLI logs trata JsonCorruptionError como warning e segue execução

## What changed
Adiciona migration `005_tasks_json_check` (up/down) para reforçar validade JSON em colunas TEXT da tabela tasks. Introduz `JsonCorruptionError` com metadados de row/column/rawValue e aplica parsing defensivo nos repositórios de tasks e events. O comando `clawde logs` agora ignora linhas corrompidas com warning explícito e mantém exit code 0.

## Acceptance criteria validated
- [x] T-086 criteria
- [x] T-087 criteria
- [x] T-088 criteria
- [x] T-089 criteria
- [x] T-090 criteria
- [x] T-091 criteria

## CI
- [x] bun run typecheck clean
- [x] bun run lint clean (somente 2 warnings preexistentes nos bootstrap tests)
- [x] bun test passing (627 pass)

## Notes for reviewer
- `runQueue` não lê rows do SQLite, então o path de warning por row corrompida (T-091) foi aplicado em `runLogs`, que é o comando CLI que consulta `events`.
- Foram adicionados testes para corrupção simulada usando `PRAGMA ignore_check_constraints = ON`.

## Cross-wave dependencies
- Nenhuma.

Implemented by Codex
