### PR TITLE
P2.6: fail-closed allowlist + migrate audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ max_memory_mb = 1024
 ```
 
 Defaults sane por agente em `defaultLevelForAgent` (`telegram-bot`/`github-pr-handler` → 3,
-`implementer`/`debugger` → 2, demais → 1). Hoje, no runtime de produção, o worker segue
-com hardening systemd nível 1; os gates de tool calls (`Bash`, `Edit`, `Write`) via hooks
-estão implementados, mas só serão aplicados no path principal após o wire-up de T-064/P2.5a.
-Ver ADR 0015.
+`implementer`/`debugger` → 2, demais → 1). No runtime atual, os gates de tool calls
+(`Bash`, `Edit`, `Write`, `Read`) estão wirados no loop principal. `network="allowlist"`
+permanece aceito no schema por compatibilidade, mas está em **fail-closed** até existir
+backend nftables/netns: use `host` explicitamente para rede aberta. Ver ADR 0015.
 
 ## Inspirações
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -46,7 +46,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P2.5b | `task/P2.5b-agent-files` | T-069..T-076 | codex | claude (+ operador em T-075/076) | merged, PR #12, 2026-04-30 | #12 |
 | P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | merged, PR #17, 2026-04-30 | #17 |
 | P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | merged, PR #19, 2026-04-30 | #19 |
-| P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | pending | — |
+| P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | in-progress, codex | — |
 | P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | pending | — |
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | merged, PR #18, 2026-04-30 | #18 |
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | pending | — |
@@ -199,7 +199,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-091 — merged, PR #19, 2026-04-30
 
 ### P2.6 — Allowlist falsa
-- [ ] T-092 — pending
+- [ ] T-092 — in-progress, codex
 - [ ] T-093 — pending
 - [ ] T-094 — pending
 - [ ] T-095 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -46,7 +46,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P2.5b | `task/P2.5b-agent-files` | T-069..T-076 | codex | claude (+ operador em T-075/076) | merged, PR #12, 2026-04-30 | #12 |
 | P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | merged, PR #17, 2026-04-30 | #17 |
 | P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | merged, PR #19, 2026-04-30 | #19 |
-| P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | in-progress, codex | — |
+| P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | in-review, codex | — |
 | P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | pending | — |
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | merged, PR #18, 2026-04-30 | #18 |
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | pending | — |
@@ -199,11 +199,11 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-091 — merged, PR #19, 2026-04-30
 
 ### P2.6 — Allowlist falsa
-- [ ] T-092 — in-progress, codex
-- [ ] T-093 — pending
-- [ ] T-094 — pending
-- [ ] T-095 — pending
-- [ ] T-096 — pending
+- [x] T-092 — in-review, codex, 2026-04-30
+- [x] T-093 — in-review, codex, 2026-04-30
+- [x] T-094 — in-review, codex, 2026-04-30
+- [x] T-095 — in-review, codex, 2026-04-30
+- [x] T-096 — in-review, codex, 2026-04-30
 
 ### P2.7 — Redact em events
 - [ ] T-097 — pending

--- a/config/clawde.toml.example
+++ b/config/clawde.toml.example
@@ -47,6 +47,9 @@ default_level             = 1                                          # 1 (syst
 bwrap_path                = "/usr/bin/bwrap"
 allow_levels_per_agent    = true
 egress_allowlist_path     = "~/.clawde/config/egress_allowlist.txt"
+# Nota: network="allowlist" nos sandbox.toml dos agentes permanece em roadmap
+# (backend nftables/netns). Runtime atual é fail-closed para esse modo; use
+# network="host" explicitamente quando quiser rede aberta.
 
 [memory]
 backend                  = "native"                          # native | claude-mem-deprecated

--- a/docs/adr/0005-sandbox-levels.md
+++ b/docs/adr/0005-sandbox-levels.md
@@ -47,6 +47,9 @@ MemoryDenyWriteExecute=yes
 não-confiável + tools com I/O de rede)
 - `--unshare-net --share-net` desligado, loopback only OU allowlist via nftables.
 - DNS via resolver local que só responde domínios da allowlist.
+- **Estado atual (P2.6):** `network='allowlist'` fica fail-closed no runtime até o
+  backend nftables/netns ser implementado; `host` deve ser usado explicitamente quando
+  a intenção for rede aberta.
 
 Matriz padrão por agente em §5.3 do `BLUEPRINT.md`. Verificação contínua via testes E2E
 de fuga (BEST_PRACTICES §3.5) e `systemd-analyze security` (score ≤2.0).

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -5,12 +5,16 @@
 
 import { type ClawdeDatabase, closeDb, openDb } from "@clawde/db/client";
 import { applyPending, defaultMigrationsDir, rollbackTo, status } from "@clawde/db/migrations";
+import { loadAllAgents } from "@clawde/sandbox";
 import { type OutputFormat, emit, emitErr } from "../output.ts";
 
 export interface MigrateOptions {
   readonly dbPath: string;
   readonly migrationsDir?: string;
   readonly format: OutputFormat;
+  readonly agentsRoot?: string;
+  readonly auditSandboxAllowlist?: boolean;
+  readonly failOnSandboxAllowlist?: boolean;
 }
 
 interface MigrateUpOptions extends MigrateOptions {
@@ -29,11 +33,37 @@ interface MigrateDownOptions extends MigrateOptions {
 
 export type MigrateAction = MigrateUpOptions | MigrateStatusOptions | MigrateDownOptions;
 
+function runSandboxAllowlistAudit(
+  agentsRoot: string,
+  failOnFindings: boolean,
+): { readonly findings: ReadonlyArray<string>; readonly shouldFail: boolean } {
+  const agents = loadAllAgents(agentsRoot);
+  const findings = agents
+    .filter((agent) => agent.sandbox.network === "allowlist")
+    .map((agent) => `${agent.name} (${agent.dir}/sandbox.toml)`);
+
+  if (findings.length === 0) {
+    return { findings, shouldFail: false };
+  }
+
+  emitErr("WARN: sandbox allowlist backend is not implemented yet (P2.6 fail-closed).");
+  emitErr("Agents using network='allowlist':");
+  for (const finding of findings) {
+    emitErr(`  - ${finding}`);
+  }
+  emitErr("Use network='host' explicitly for open network, or loopback-only/none for isolation.");
+
+  return { findings, shouldFail: failOnFindings };
+}
+
 /**
  * Executa o subcomando. Retorna exit code (0 = sucesso, 1+ = erro).
  */
 export function runMigrate(action: MigrateAction): number {
   const dir = action.migrationsDir ?? defaultMigrationsDir();
+  const agentsRoot = action.agentsRoot ?? ".claude/agents";
+  const auditSandboxAllowlist = action.auditSandboxAllowlist === true;
+  const failOnSandboxAllowlist = action.failOnSandboxAllowlist === true;
   let db: ClawdeDatabase;
   try {
     db = openDb(action.dbPath);
@@ -64,6 +94,12 @@ export function runMigrate(action: MigrateAction): number {
         ];
         return lines.join("\n");
       });
+      if (auditSandboxAllowlist) {
+        const audit = runSandboxAllowlistAudit(agentsRoot, failOnSandboxAllowlist);
+        if (audit.shouldFail && audit.findings.length > 0) {
+          return 2;
+        }
+      }
       return 0;
     }
     // down

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -107,6 +107,11 @@ Commands:
 Common options:
   --db <path>            DB path (default ~/.clawde/state.db ou env CLAWDE_DB)
   --output {text|json}   Formato de output (default text)
+
+Migrate options:
+  --audit-sandbox        Em migrate status, audita agentes com network="allowlist"
+  --fail-on-allowlist    Com --audit-sandbox, retorna exit 2 se houver achados
+  --agents-root <path>   Root dos agentes (default .claude/agents)
 `;
 
 export async function runMain(argv: ReadonlyArray<string>): Promise<number> {
@@ -140,12 +145,27 @@ export async function runMain(argv: ReadonlyArray<string>): Promise<number> {
     const action = parsed.positional[0] ?? "status";
     const dbPath = getDbPath(parsed);
     const format = getOutputFormat(parsed);
-    if (action === "up") return runMigrate({ action: "up", dbPath, format });
-    if (action === "status") return runMigrate({ action: "status", dbPath, format });
+    const migrateCommon: Omit<Parameters<typeof runMigrate>[0], "action"> = {
+      dbPath,
+      format,
+    };
+    if (parsed.flags["audit-sandbox"] === true) {
+      Object.assign(migrateCommon, { auditSandboxAllowlist: true });
+    }
+    if (parsed.flags["fail-on-allowlist"] === true) {
+      Object.assign(migrateCommon, { failOnSandboxAllowlist: true });
+    }
+    const agentsRoot = getFlag(parsed, "agents-root");
+    if (agentsRoot !== undefined && agentsRoot.length > 0) {
+      Object.assign(migrateCommon, { agentsRoot });
+    }
+
+    if (action === "up") return runMigrate({ action: "up", ...migrateCommon });
+    if (action === "status") return runMigrate({ action: "status", ...migrateCommon });
     if (action === "down") {
       const target = Number.parseInt(getFlag(parsed, "target", "0") ?? "0", 10);
       const confirm = parsed.flags.confirm === true;
-      return runMigrate({ action: "down", dbPath, format, target, confirm });
+      return runMigrate({ action: "down", ...migrateCommon, target, confirm });
     }
     emitErr(`unknown migrate action: ${action}`);
     return 1;

--- a/src/sandbox/agent-config.ts
+++ b/src/sandbox/agent-config.ts
@@ -11,6 +11,8 @@ import { parse as parseTOML } from "smol-toml";
 import { z } from "zod";
 import type { SandboxLevel } from "./bwrap.ts";
 
+// Mantemos "allowlist" no schema por compatibilidade de config.
+// Em runtime (P2.6), bwrap falha fechada até backend nftables existir.
 export const NetworkModeSchema = z.enum(["allowlist", "loopback-only", "none", "host"]);
 
 export const SandboxLevelSchema = z.union([z.literal(1), z.literal(2), z.literal(3)]);

--- a/src/sandbox/bwrap.ts
+++ b/src/sandbox/bwrap.ts
@@ -24,6 +24,11 @@ export interface BwrapConfig {
   readonly readWritePaths: ReadonlyArray<{ host: string; sandbox: string }>;
   /** Modo de rede. */
   readonly network: NetworkMode;
+  /**
+   * Backend real de allowlist (nftables/netns) disponível.
+   * Enquanto false/undefined, network='allowlist' falha fechada.
+   */
+  readonly allowlistBackendAvailable?: boolean;
   /** Working directory dentro do sandbox. */
   readonly workdir?: string;
   /** Variáveis de ambiente (passadas pra bwrap --setenv). */
@@ -90,7 +95,11 @@ export function buildBwrapArgs(
   if (config.network === "host") {
     args.push("--share-net");
   } else if (config.network === "allowlist") {
-    // Allowlist real precisa nftables setup externo (T57); aqui só não unshare net.
+    if (config.allowlistBackendAvailable !== true) {
+      throw new Error(
+        "network='allowlist' requires nftables backend not yet implemented. Use 'host' explicitly.",
+      );
+    }
     args.push("--share-net");
   }
   // 'loopback-only' e 'none' = mantém net unshared. loopback exists by default

--- a/src/sandbox/matrix.ts
+++ b/src/sandbox/matrix.ts
@@ -5,8 +5,8 @@
  * Nível 1: systemd hardening only (sem bwrap). materializeSandbox retorna
  *   "level": 1 com runDirect = true; chamador usa execFile direto.
  *
- * Nível 2: bwrap com bind read-only de /usr|/lib|/etc/ssl, RW só do worktree,
- *   network='allowlist' (host net por enquanto, allowlist real fica futuro).
+ * Nível 2: bwrap com bind read-only de /usr|/lib|/etc/ssl, RW só do worktree.
+ *   network='allowlist' falha fechada até backend nftables existir (P2.6).
  *
  * Nível 3: bwrap nivel 2 + applyNetnsToConfig (loopback-only, custom resolv.conf).
  */
@@ -51,6 +51,7 @@ export function materializeSandbox(input: MaterializeInput): MaterializedSandbox
       { host: input.workspacePath, sandbox: "/workspace" },
     ],
     network: input.agent.network,
+    allowlistBackendAvailable: false,
     workdir: "/workspace",
     env: {
       HOME: "/workspace",

--- a/tests/integration/cli-migrate.test.ts
+++ b/tests/integration/cli-migrate.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runMigrate } from "@clawde/cli/commands/migrate";
@@ -107,5 +107,53 @@ describe("cli/commands/migrate", () => {
     );
     expect(exit).toBe(2);
     expect(stderr).toContain("error:");
+  });
+
+  test("status com auditoria sem allowlist retorna 0", () => {
+    const agentsRoot = join(dir, ".claude", "agents");
+    mkdirSync(join(agentsRoot, "default"), { recursive: true });
+    writeFileSync(
+      join(agentsRoot, "default", "sandbox.toml"),
+      ["level = 1", 'network = "none"'].join("\n"),
+      "utf-8",
+    );
+
+    runMigrate({ action: "up", dbPath, format: "text" });
+    const { exit, stderr } = captureOutput(() =>
+      runMigrate({
+        action: "status",
+        dbPath,
+        format: "text",
+        agentsRoot,
+        auditSandboxAllowlist: true,
+      }),
+    );
+    expect(exit).toBe(0);
+    expect(stderr).not.toContain("network='allowlist'");
+  });
+
+  test("status com auditoria e fail-on-allowlist retorna 2 quando encontra allowlist", () => {
+    const agentsRoot = join(dir, ".claude", "agents");
+    mkdirSync(join(agentsRoot, "telegram-bot"), { recursive: true });
+    writeFileSync(
+      join(agentsRoot, "telegram-bot", "sandbox.toml"),
+      ["level = 3", 'network = "allowlist"'].join("\n"),
+      "utf-8",
+    );
+
+    runMigrate({ action: "up", dbPath, format: "text" });
+    const { exit, stderr } = captureOutput(() =>
+      runMigrate({
+        action: "status",
+        dbPath,
+        format: "text",
+        agentsRoot,
+        auditSandboxAllowlist: true,
+        failOnSandboxAllowlist: true,
+      }),
+    );
+    expect(exit).toBe(2);
+    expect(stderr).toContain("network='allowlist'");
+    expect(stderr).toContain("telegram-bot");
   });
 });

--- a/tests/integration/sandbox-bwrap.test.ts
+++ b/tests/integration/sandbox-bwrap.test.ts
@@ -72,6 +72,36 @@ describe("sandbox/bwrap buildBwrapArgs", () => {
     expect(args).not.toContain("--share-net");
     expect(args).toContain("--unshare-all");
   });
+
+  test("network=allowlist falha fechada sem backend nftables", () => {
+    expect(() =>
+      buildBwrapArgs(
+        {
+          readOnlyMounts: [],
+          readWritePaths: [],
+          network: "allowlist",
+        },
+        "/bin/true",
+        [],
+      ),
+    ).toThrow(
+      "network='allowlist' requires nftables backend not yet implemented. Use 'host' explicitly.",
+    );
+  });
+
+  test("network=allowlist com backend disponível adiciona --share-net", () => {
+    const args = buildBwrapArgs(
+      {
+        readOnlyMounts: [],
+        readWritePaths: [],
+        network: "allowlist",
+        allowlistBackendAvailable: true,
+      },
+      "/bin/true",
+      [],
+    );
+    expect(args).toContain("--share-net");
+  });
 });
 
 describe("sandbox/bwrap isBwrapAvailable", () => {


### PR DESCRIPTION
## Summary
- implement T-092/T-094: fail-closed runtime behavior for `network="allowlist"` in bwrap while preserving schema compatibility
- implement T-093: docs alignment in README, ADR 0005, and config example
- implement T-095: migrate status sandbox audit flags (`--audit-sandbox`, `--fail-on-allowlist`, `--agents-root`)
- implement T-096: tests for fail-closed allowlist and backend-enabled path
- update STATUS.md to P2.6 in-review

## Validation
- bun run typecheck
- bun run lint
- bun test (historical flaky test may fail intermittently in WSL/NTFS; reviewer validated clean run on Linux ext4)

## Review Notes
- Claude review: APPROVED for T-092..T-096
- Security note: T-092 and T-096 require dual review/operator approval before merge
