### PR TITLE
P2.7: redact event payloads and tool_use summaries

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,7 +47,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | merged, PR #17, 2026-04-30 | #17 |
 | P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | merged, PR #19, 2026-04-30 | #19 |
 | P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | merged, PR #21, 2026-04-30 | #21 |
-| P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | in-progress, codex | — |
+| P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | in-review, codex | — |
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | merged, PR #18, 2026-04-30 | #18 |
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | pending | — |
 | P3.4 | `task/P3.4-reflect-job` | T-112..T-115 | claude | codex | pending | — |
@@ -206,10 +206,10 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-096 — merged, PR #21, 2026-04-30
 
 ### P2.7 — Redact em events
-- [ ] T-097 — in-progress, codex
-- [ ] T-098 — pending
-- [ ] T-099 — pending
-- [ ] T-100 — pending
+- [x] T-097 — in-review, codex, 2026-04-30
+- [x] T-098 — in-review, codex, 2026-04-30
+- [x] T-099 — in-review, codex, 2026-04-30
+- [x] T-100 — in-review, codex, 2026-04-30
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -47,7 +47,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P1.4 | `task/P1.4-event-kind` | T-079..T-085 | codex | claude | merged, PR #17, 2026-04-30 | #17 |
 | P1.5 | `task/P1.5-json-validity` | T-086..T-091 | codex | claude | merged, PR #19, 2026-04-30 | #19 |
 | P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | merged, PR #21, 2026-04-30 | #21 |
-| P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | pending | — |
+| P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | in-progress, codex | — |
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | merged, PR #18, 2026-04-30 | #18 |
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | pending | — |
 | P3.4 | `task/P3.4-reflect-job` | T-112..T-115 | claude | codex | pending | — |
@@ -206,7 +206,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-096 — merged, PR #21, 2026-04-30
 
 ### P2.7 — Redact em events
-- [ ] T-097 — pending
+- [ ] T-097 — in-progress, codex
 - [ ] T-098 — pending
 - [ ] T-099 — pending
 - [ ] T-100 — pending

--- a/docs/adr/0016-events-scrub-policy.md
+++ b/docs/adr/0016-events-scrub-policy.md
@@ -1,0 +1,32 @@
+# ADR 0016 — Política para scrub de events históricos
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Decisores:** @Incavenuziano
+
+## Contexto
+
+P2.7 passou a redigir payloads novos em `events` no momento do `INSERT`.
+Ainda pode existir histórico antigo com dados sensíveis. O problema: `events` é
+append-only por contrato (triggers de imutabilidade e auditoria).
+
+## Decisão
+
+No MVP, não haverá update destrutivo automático em `events`.
+
+1. manter histórico imutável por padrão;
+2. oferecer auditoria (lookup/report) para identificar rows potencialmente
+   sensíveis;
+3. qualquer scrub destrutivo futuro exige comando/manual mode explícito do
+   operador e decisão separada.
+
+## Consequências
+
+- preserva o contrato append-only e evita mutação silenciosa de trilha de audit;
+- risco residual no legado é tratado operacionalmente (auditoria + decisão humana);
+- evita criar ferramenta de “edição retroativa” sem governança.
+
+## Alternativas consideradas
+
+- scrub automático pós-migração: reduz risco de segredo, mas viola append-only;
+- sobrescrever rows antigas in-place: simples tecnicamente, frágil em auditoria.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ Registros das decisões arquiteturais não-triviais do Clawde. Formato baseado e
 | [0012](0012-single-provider-anthropic.md) | Accepted | Single-provider Anthropic + risco aceito |
 | [0013](0013-sandbox-bwrap-implementation.md) | Superseded by 0015 | Sandbox Nível 2/3: implementação via bubblewrap |
 | [0015](0015-sandbox-tools-not-process.md) | Accepted | Sandbox 2/3 aplicado em tool calls (`Bash`/`Edit`/`Write`) |
+| [0016](0016-events-scrub-policy.md) | Accepted | Events legados: auditoria sem scrub destrutivo automático |
 
 ## Convenções
 

--- a/src/db/repositories/events.ts
+++ b/src/db/repositories/events.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Event, EventKind, NewEvent } from "@clawde/domain/event";
+import { redact } from "@clawde/log";
 import type { ClawdeDatabase } from "../client.ts";
 import { JsonCorruptionError } from "./tasks.ts";
 
@@ -68,6 +69,7 @@ export class EventsRepo {
    * INSERT em events. Único write permitido (UPDATE/DELETE bloqueados por triggers).
    */
   insert(input: NewEvent): Event {
+    const safePayload = redact(input.payload) as Record<string, unknown>;
     const row = this.db
       .query<
         RawEventRow,
@@ -83,7 +85,7 @@ export class EventsRepo {
         input.traceId,
         input.spanId,
         input.kind,
-        JSON.stringify(input.payload),
+        JSON.stringify(safePayload),
       );
     if (row === null) {
       throw new Error("INSERT...RETURNING returned null");

--- a/src/hooks/handlers.ts
+++ b/src/hooks/handlers.ts
@@ -39,6 +39,63 @@ export interface PreToolUseAgentPolicy {
   };
 }
 
+function summarizeBashCommand(toolInput: Readonly<Record<string, unknown>>): string {
+  const raw = toolInput.command;
+  if (typeof raw !== "string") return "";
+  return raw.slice(0, 80);
+}
+
+function extractPath(toolInput: Readonly<Record<string, unknown>>): string {
+  const candidates = [toolInput.path, toolInput.file_path];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") return candidate;
+  }
+  return "";
+}
+
+function estimateWriteBytes(toolInput: Readonly<Record<string, unknown>>): number {
+  const candidates = [
+    toolInput.content,
+    toolInput.text,
+    toolInput.newText,
+    toolInput.new_str,
+    toolInput.old_str,
+    toolInput.patch,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      return Buffer.byteLength(candidate, "utf-8");
+    }
+  }
+  return 0;
+}
+
+function summarizeToolUse(
+  toolName: string,
+  toolInput: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  if (toolName === "Bash") {
+    return {
+      tool_name: "Bash",
+      command_summary: summarizeBashCommand(toolInput),
+    };
+  }
+  if (toolName === "Read") {
+    return {
+      tool_name: "Read",
+      path: extractPath(toolInput),
+    };
+  }
+  if (toolName === "Edit" || toolName === "Write") {
+    return {
+      tool_name: toolName,
+      path: extractPath(toolInput),
+      bytes_count: estimateWriteBytes(toolInput),
+    };
+  }
+  return { tool_name: toolName };
+}
+
 function normalizePath(input: string): string {
   return input.replace(/\\/g, "/").trim();
 }
@@ -111,8 +168,7 @@ export function makePreToolUseHandler(
     }
 
     if (toolName === "Edit" || toolName === "Write") {
-      const rawPath = input.payload.toolInput.path;
-      const path = typeof rawPath === "string" ? rawPath : "";
+      const path = extractPath(input.payload.toolInput);
       const allowedWrites = agent?.sandbox.allowed_writes ?? [];
       if (allowedWrites.length > 0 && !isAllowedWritePath(path, allowedWrites)) {
         emit("tool_blocked", {
@@ -124,7 +180,7 @@ export function makePreToolUseHandler(
       }
     }
 
-    emit("tool_use", { tool: input.payload.toolName, input: input.payload.toolInput });
+    emit("tool_use", summarizeToolUse(input.payload.toolName, input.payload.toolInput));
     return { ok: true };
   };
 }

--- a/src/log/secrets.ts
+++ b/src/log/secrets.ts
@@ -41,6 +41,7 @@ export const SECRET_KEY_PATTERNS = [
  * Padrões de regex para valores que parecem secrets independentemente da chave.
  */
 export const SECRET_VALUE_PATTERNS: ReadonlyArray<RegExp> = [
+  /sk-ant-[a-zA-Z0-9_-]+/g, // Anthropic generic token (inclui fakes/curtos em testes)
   /sk-ant-[a-zA-Z0-9_-]{32,}/g, // Anthropic API key
   /sk-ant-oat01-[a-zA-Z0-9_-]+/g, // Anthropic OAuth token
   /ghp_[a-zA-Z0-9]{36,}/g, // GitHub PAT

--- a/tests/security/log-redaction.test.ts
+++ b/tests/security/log-redaction.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EventsRepo } from "@clawde/db/repositories/events";
+import { REDACTED_PLACEHOLDER } from "@clawde/log";
+import { type TestDb, makeTestDb } from "../helpers/db.ts";
+
+describe("security/event payload redaction", () => {
+  let testDb: TestDb;
+  let repo: EventsRepo;
+
+  beforeEach(() => {
+    testDb = makeTestDb();
+    repo = new EventsRepo(testDb.db);
+  });
+
+  afterEach(() => {
+    testDb.cleanup();
+  });
+
+  test("tool_use com token em Bash command persiste payload redigido", () => {
+    const event = repo.insert({
+      taskRunId: null,
+      sessionId: null,
+      traceId: "trace-redact",
+      spanId: null,
+      kind: "tool_use",
+      payload: {
+        tool_name: "Bash",
+        command_summary: "echo sk-ant-fake-token-123",
+      },
+    });
+
+    expect(event.payload.command_summary).toContain(REDACTED_PLACEHOLDER);
+    expect(event.payload.command_summary).not.toContain("sk-ant-fake-token-123");
+  });
+});

--- a/tests/unit/hooks/pipeline.test.ts
+++ b/tests/unit/hooks/pipeline.test.ts
@@ -158,7 +158,7 @@ describe("hooks/handlers default emitem eventos via callback", () => {
     expect(events[0]?.payload.source).toBe("cli");
   });
 
-  test("makePreToolUseHandler captura toolName + input", async () => {
+  test("makePreToolUseHandler emite resumo allowlisted para Bash", async () => {
     const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
     const handler = makePreToolUseHandler((kind, payload) => events.push({ kind, payload }));
     await handler(
@@ -168,7 +168,47 @@ describe("hooks/handlers default emitem eventos via callback", () => {
       },
     );
     expect(events[0]?.kind).toBe("tool_use");
-    expect(events[0]?.payload.tool).toBe("Bash");
+    expect(events[0]?.payload).toEqual({
+      tool_name: "Bash",
+      command_summary: "ls",
+    });
+  });
+
+  test("makePreToolUseHandler emite path para Read", async () => {
+    const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+    const handler = makePreToolUseHandler((kind, payload) => events.push({ kind, payload }));
+    await handler(
+      preToolInput({
+        toolName: "Read",
+        toolInput: { path: "/tmp/x.txt", token: "secret" },
+      }) as HookInput & {
+        hook: "PreToolUse";
+        payload: PreToolUsePayload;
+      },
+    );
+    expect(events[0]?.payload).toEqual({
+      tool_name: "Read",
+      path: "/tmp/x.txt",
+    });
+  });
+
+  test("makePreToolUseHandler emite path + bytes_count para Edit/Write", async () => {
+    const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+    const handler = makePreToolUseHandler((kind, payload) => events.push({ kind, payload }));
+    await handler(
+      preToolInput({
+        toolName: "Edit",
+        toolInput: { path: "/workspace/a.ts", newText: "abc" },
+      }) as HookInput & {
+        hook: "PreToolUse";
+        payload: PreToolUsePayload;
+      },
+    );
+    expect(events[0]?.payload).toEqual({
+      tool_name: "Edit",
+      path: "/workspace/a.ts",
+      bytes_count: 3,
+    });
   });
 
   test("makePreToolUseHandler bloqueia tool fora de allowedTools", async () => {


### PR DESCRIPTION
## Summary
- T-097: apply `redact()` inside `EventsRepo.insert()` before persisting payload JSON
- T-098: emit allowlisted `tool_use` payloads from PreToolUse handler:
  - Bash: `command_summary` (first 80 chars)
  - Read: `path`
  - Edit/Write: `path` + `bytes_count`
  - Other tools: `tool_name` only
- T-099: add security test validating persisted `tool_use` payload redacts `sk-ant-*` token values
- T-100: add ADR 0016 defining policy for legacy `events` scrub (no destructive default)
- update STATUS.md to P2.7 in-review

## Validation
- `bun run typecheck` ✅
- `bun run lint` ✅ (2 pre-existing warnings in bootstrap tests)
- `bun test` ⚠️ 1 historical flaky (`findExpiredLeases`) reproduced once in full suite
- Focused tests for P2.7 passed:
  - `bun test tests/security/log-redaction.test.ts tests/unit/db/events.repo.test.ts tests/unit/hooks/pipeline.test.ts`

## Security / Review
- P2.7 includes security tasks with dual review scope (T-097..T-099).
