### PR TITLE
P3.5: smoke service alinhado

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -51,7 +51,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | merged, PR #18, 2026-04-30 | #18 |
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | pending | — |
 | P3.4 | `task/P3.4-reflect-job` | T-112..T-115 | claude | codex | pending | — |
-| P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | in-progress, codex | — |
+| P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | in-review, PR #23 | #23 |
 | P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | pending | — |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | pending | — |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | pending | — |
@@ -242,12 +242,12 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-115 — pending
 
 ### P3.5 — Smoke service alinhado
-- [ ] T-116 — in-progress, codex
-- [ ] T-117 — pending
-- [ ] T-118 — pending
-- [ ] T-119 — pending
-- [ ] T-120 — pending
-- [ ] T-121 — pending
+- [x] T-116 — in-review, PR #23
+- [x] T-117 — in-review, PR #23
+- [x] T-118 — in-review, PR #23
+- [x] T-119 — in-review, PR #23
+- [x] T-120 — in-review, PR #23
+- [x] T-121 — in-review, PR #23
 
 ### P3.6 — SDK real validation
 - [ ] T-122 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -300,7 +300,7 @@ e produz `docs/wave-summaries/wave-N.md`.
 - [ ] Wave 1 audit — pending (reviewer: codex)
 - [x] Wave 2 audit — done (reviewer: claude, docs/wave-summaries/wave-2.md)
 - [ ] Wave 3 audit — pending (reviewer: codex)
-- [ ] Wave 4 audit — pending (reviewer: claude)
+- [x] Wave 4 audit — done (reviewer: claude, docs/wave-summaries/wave-4.md, PR #23, 2026-04-30)
 - [ ] Wave 5 audit — pending (reviewer: codex)
 - [ ] Wave 6 audit — pending (reviewer: claude)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -51,7 +51,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | merged, PR #18, 2026-04-30 | #18 |
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | pending | — |
 | P3.4 | `task/P3.4-reflect-job` | T-112..T-115 | claude | codex | pending | — |
-| P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | pending | — |
+| P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | in-progress, codex | — |
 | P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | pending | — |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | pending | — |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | pending | — |
@@ -242,7 +242,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-115 — pending
 
 ### P3.5 — Smoke service alinhado
-- [ ] T-116 — pending
+- [ ] T-116 — in-progress, codex
 - [ ] T-117 — pending
 - [ ] T-118 — pending
 - [ ] T-119 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -51,7 +51,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | merged, PR #18, 2026-04-30 | #18 |
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | pending | — |
 | P3.4 | `task/P3.4-reflect-job` | T-112..T-115 | claude | codex | pending | — |
-| P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | in-review, PR #23 | #23 |
+| P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | in-review, PR #24 | #24 |
 | P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | pending | — |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | pending | — |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | pending | — |
@@ -242,12 +242,12 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [ ] T-115 — pending
 
 ### P3.5 — Smoke service alinhado
-- [x] T-116 — in-review, PR #23
-- [x] T-117 — in-review, PR #23
-- [x] T-118 — in-review, PR #23
-- [x] T-119 — in-review, PR #23
-- [x] T-120 — in-review, PR #23
-- [x] T-121 — in-review, PR #23
+- [x] T-116 — in-review, PR #24
+- [x] T-117 — in-review, PR #24
+- [x] T-118 — in-review, PR #24
+- [x] T-119 — in-review, PR #24
+- [x] T-120 — in-review, PR #24
+- [x] T-121 — in-review, PR #24
 
 ### P3.6 — SDK real validation
 - [ ] T-122 — pending

--- a/deploy/systemd/clawde-smoke.service
+++ b/deploy/systemd/clawde-smoke.service
@@ -5,7 +5,7 @@ Description=Clawde smoke test diário
 Type=oneshot
 WorkingDirectory=%h/.clawde
 EnvironmentFile=-%h/.clawde/config/clawde.env
-ExecStart=%h/.clawde/dist/clawde smoke-test
+ExecStart=%h/.clawde/dist/clawde smoke-test --output json
 
 # Hardening idêntico ao worker (BEST_PRACTICES §10.4)
 PrivateTmp=yes

--- a/src/cli/commands/smoke-test.ts
+++ b/src/cli/commands/smoke-test.ts
@@ -16,6 +16,7 @@ import { OAuthLoadError, getTokenExpiry, loadOAuthToken } from "@clawde/auth";
 import { loadConfig } from "@clawde/config";
 import { type ClawdeDatabase, closeDb, openDb } from "@clawde/db/client";
 import { defaultMigrationsDir, status } from "@clawde/db/migrations";
+import { EventsRepo } from "@clawde/db/repositories/events";
 import { RealAgentClient } from "@clawde/sdk";
 import { type OutputFormat, emit, emitErr } from "../output.ts";
 
@@ -34,6 +35,7 @@ interface CheckResult {
   readonly name: string;
   readonly ok: boolean;
   readonly detail?: string;
+  readonly eventKind?: "smoke.sdk_real_ping_ok" | "smoke.sdk_real_ping_fail";
 }
 
 interface SmokeReport {
@@ -242,15 +244,22 @@ async function checkSdkRealPing(include: boolean): Promise<CheckResult> {
         name: "sdk.real_ping",
         ok: false,
         detail: result.error ?? "unknown sdk error",
+        eventKind: "smoke.sdk_real_ping_fail",
       };
     }
     return {
       name: "sdk.real_ping",
       ok: true,
       detail: `ok (${result.msgsConsumed} msgs, stop=${result.stopReason})`,
+      eventKind: "smoke.sdk_real_ping_ok",
     };
   } catch (err) {
-    return { name: "sdk.real_ping", ok: false, detail: (err as Error).message };
+    return {
+      name: "sdk.real_ping",
+      ok: false,
+      detail: (err as Error).message,
+      eventKind: "smoke.sdk_real_ping_fail",
+    };
   }
 }
 
@@ -274,7 +283,8 @@ export async function runSmokeTest(options: SmokeTestOptions): Promise<number> {
   checks.push(await checkWorkerDryRun());
   checks.push(checkBwrapForSandboxAgents());
   checks.push(checkOAuthExpiry());
-  checks.push(await checkSdkRealPing(options.includeSdkPing === true));
+  const sdkPing = await checkSdkRealPing(options.includeSdkPing === true);
+  checks.push(sdkPing);
 
   if (options.receiverUrl !== undefined && options.receiverUrl.length > 0) {
     checks.push(await checkReceiverHealth(options.receiverUrl, options.receiverTimeoutMs ?? 2000));
@@ -282,6 +292,30 @@ export async function runSmokeTest(options: SmokeTestOptions): Promise<number> {
 
   const allOk = checks.every((c) => c.ok);
   const report: SmokeReport = { ok: allOk, checks };
+
+  if (sdkPing.eventKind !== undefined) {
+    try {
+      const eventsDb = openDb(options.dbPath);
+      try {
+        const events = new EventsRepo(eventsDb);
+        events.insert({
+          taskRunId: null,
+          sessionId: null,
+          traceId: null,
+          spanId: null,
+          kind: sdkPing.eventKind,
+          payload: {
+            detail: sdkPing.detail ?? "",
+            ok: sdkPing.ok,
+          },
+        });
+      } finally {
+        closeDb(eventsDb);
+      }
+    } catch {
+      // Smoke não falha por erro de telemetria.
+    }
+  }
 
   emit(options.format, report, (d) => {
     const data = d as SmokeReport;

--- a/src/cli/commands/smoke-test.ts
+++ b/src/cli/commands/smoke-test.ts
@@ -10,10 +10,9 @@
  */
 
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { AgentDefinitionError, loadAllAgentDefinitions } from "@clawde/agents";
 import { OAuthLoadError, getTokenExpiry, loadOAuthToken } from "@clawde/auth";
-import { loadConfig } from "@clawde/config";
 import { type ClawdeDatabase, closeDb, openDb } from "@clawde/db/client";
 import { defaultMigrationsDir, status } from "@clawde/db/migrations";
 import { EventsRepo } from "@clawde/db/repositories/events";
@@ -41,6 +40,21 @@ interface CheckResult {
 interface SmokeReport {
   readonly ok: boolean;
   readonly checks: ReadonlyArray<CheckResult>;
+}
+
+function envForSmokeChecks(dbPath: string): Record<string, string | undefined> {
+  const explicitConfig = process.env.CLAWDE_CONFIG;
+  return {
+    ...(process.env as Record<string, string | undefined>),
+    // Torna smoke independente de ~/.clawde global em ambientes de teste.
+    CLAWDE_HOME:
+      process.env.CLAWDE_HOME !== undefined && process.env.CLAWDE_HOME.length > 0
+        ? process.env.CLAWDE_HOME
+        : dirname(dbPath),
+    // Evita acoplamento com config global implícita via $HOME quando não há
+    // CLAWDE_CONFIG explícito no ambiente.
+    CLAWDE_CONFIG: explicitConfig !== undefined && explicitConfig.length > 0 ? explicitConfig : "",
+  };
 }
 
 function checkIntegrity(db: ClawdeDatabase): CheckResult {
@@ -111,7 +125,7 @@ async function checkReceiverHealth(url: string, timeoutMs: number): Promise<Chec
   }
 }
 
-async function checkWorkerDryRun(): Promise<CheckResult> {
+async function checkWorkerDryRun(dbPath: string): Promise<CheckResult> {
   const bunPath = Bun.which("bun") ?? "bun";
   const workerPath = "dist/worker-main.js";
   if (!existsSync(workerPath)) {
@@ -124,7 +138,7 @@ async function checkWorkerDryRun(): Promise<CheckResult> {
   const proc = Bun.spawn([bunPath, "run", workerPath, "--dry-run"], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env },
+    env: envForSmokeChecks(dbPath),
   });
   const [exitCode, stdout, stderr] = await Promise.all([
     proc.exited,
@@ -147,10 +161,10 @@ async function checkWorkerDryRun(): Promise<CheckResult> {
   };
 }
 
-function checkBwrapForSandboxAgents(): CheckResult {
+function checkBwrapForSandboxAgents(dbPath: string): CheckResult {
   try {
-    const config = loadConfig();
-    const root = join(config.clawde.home, "agents");
+    const env = envForSmokeChecks(dbPath);
+    const root = join(env.CLAWDE_HOME ?? dirname(dbPath), "agents");
     const defs = loadAllAgentDefinitions(root);
     const needsBwrap = defs.some((d) => d.sandbox.level >= 2);
     if (!needsBwrap) {
@@ -280,8 +294,8 @@ export async function runSmokeTest(options: SmokeTestOptions): Promise<number> {
     closeDb(db);
   }
 
-  checks.push(await checkWorkerDryRun());
-  checks.push(checkBwrapForSandboxAgents());
+  checks.push(await checkWorkerDryRun(options.dbPath));
+  checks.push(checkBwrapForSandboxAgents(options.dbPath));
   checks.push(checkOAuthExpiry());
   const sdkPing = await checkSdkRealPing(options.includeSdkPing === true);
   checks.push(sdkPing);

--- a/src/cli/commands/smoke-test.ts
+++ b/src/cli/commands/smoke-test.ts
@@ -9,8 +9,14 @@
  * Worker dry-run + CLI version checks vêm em fases posteriores.
  */
 
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { AgentDefinitionError, loadAllAgentDefinitions } from "@clawde/agents";
+import { OAuthLoadError, getTokenExpiry, loadOAuthToken } from "@clawde/auth";
+import { loadConfig } from "@clawde/config";
 import { type ClawdeDatabase, closeDb, openDb } from "@clawde/db/client";
 import { defaultMigrationsDir, status } from "@clawde/db/migrations";
+import { RealAgentClient } from "@clawde/sdk";
 import { type OutputFormat, emit, emitErr } from "../output.ts";
 
 export interface SmokeTestOptions {
@@ -20,6 +26,8 @@ export interface SmokeTestOptions {
   readonly receiverUrl?: string;
   /** Timeout pra check de receiver. */
   readonly receiverTimeoutMs?: number;
+  /** Habilita ping real no SDK quando token estiver presente. */
+  readonly includeSdkPing?: boolean;
 }
 
 interface CheckResult {
@@ -101,6 +109,151 @@ async function checkReceiverHealth(url: string, timeoutMs: number): Promise<Chec
   }
 }
 
+async function checkWorkerDryRun(): Promise<CheckResult> {
+  const bunPath = Bun.which("bun") ?? "bun";
+  const workerPath = "dist/worker-main.js";
+  if (!existsSync(workerPath)) {
+    return {
+      name: "worker.dry_run",
+      ok: false,
+      detail: `${workerPath} not found (run bun run build:worker)`,
+    };
+  }
+  const proc = Bun.spawn([bunPath, "run", workerPath, "--dry-run"], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env },
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const output = `${stdout}\n${stderr}`;
+  if (exitCode !== 0) {
+    return {
+      name: "worker.dry_run",
+      ok: false,
+      detail: `exit=${exitCode}`,
+    };
+  }
+  return {
+    name: "worker.dry_run",
+    ok: true,
+    detail:
+      output.trim().length > 0 ? "worker dry-run exited 0" : "worker dry-run exited 0 (silent)",
+  };
+}
+
+function checkBwrapForSandboxAgents(): CheckResult {
+  try {
+    const config = loadConfig();
+    const root = join(config.clawde.home, "agents");
+    const defs = loadAllAgentDefinitions(root);
+    const needsBwrap = defs.some((d) => d.sandbox.level >= 2);
+    if (!needsBwrap) {
+      return {
+        name: "sandbox.bwrap_presence",
+        ok: true,
+        detail: "no level>=2 agents loaded",
+      };
+    }
+    const bwrapPath = "/usr/bin/bwrap";
+    return {
+      name: "sandbox.bwrap_presence",
+      ok: existsSync(bwrapPath),
+      detail: existsSync(bwrapPath)
+        ? `${bwrapPath} present`
+        : `${bwrapPath} missing but level>=2 agents exist`,
+    };
+  } catch (err) {
+    const detail = err instanceof AgentDefinitionError ? err.message : (err as Error).message;
+    return {
+      name: "sandbox.bwrap_presence",
+      ok: false,
+      detail,
+    };
+  }
+}
+
+function checkOAuthExpiry(): CheckResult {
+  try {
+    const token = loadOAuthToken();
+    const expiry = getTokenExpiry(token.value);
+    if (expiry.daysUntilExpiry === null) {
+      return {
+        name: "auth.oauth_expiry",
+        ok: true,
+        detail: "token loaded; expiry unknown (non-JWT or missing exp)",
+      };
+    }
+    const days = Math.round(expiry.daysUntilExpiry * 10) / 10;
+    if (days < 7) {
+      return {
+        name: "auth.oauth_expiry",
+        ok: false,
+        detail: `expires in ${days}d (<7d)`,
+      };
+    }
+    if (days < 30) {
+      return {
+        name: "auth.oauth_expiry",
+        ok: true,
+        detail: `warning: expires in ${days}d (<30d)`,
+      };
+    }
+    return {
+      name: "auth.oauth_expiry",
+      ok: true,
+      detail: `expires in ${days}d`,
+    };
+  } catch (err) {
+    if (err instanceof OAuthLoadError) {
+      return {
+        name: "auth.oauth_expiry",
+        ok: true,
+        detail: "token not found; check skipped",
+      };
+    }
+    return {
+      name: "auth.oauth_expiry",
+      ok: false,
+      detail: (err as Error).message,
+    };
+  }
+}
+
+async function checkSdkRealPing(include: boolean): Promise<CheckResult> {
+  if (!include) {
+    return { name: "sdk.real_ping", ok: true, detail: "skipped (flag disabled)" };
+  }
+  const token = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  if (token === undefined || token.length === 0) {
+    return { name: "sdk.real_ping", ok: true, detail: "skipped (token missing)" };
+  }
+  try {
+    const client = new RealAgentClient();
+    const result = await client.run({
+      prompt: "Reply with exactly: pong",
+      maxTurns: 1,
+    });
+    if (result.stopReason === "error" || result.error !== null) {
+      return {
+        name: "sdk.real_ping",
+        ok: false,
+        detail: result.error ?? "unknown sdk error",
+      };
+    }
+    return {
+      name: "sdk.real_ping",
+      ok: true,
+      detail: `ok (${result.msgsConsumed} msgs, stop=${result.stopReason})`,
+    };
+  } catch (err) {
+    return { name: "sdk.real_ping", ok: false, detail: (err as Error).message };
+  }
+}
+
 export async function runSmokeTest(options: SmokeTestOptions): Promise<number> {
   let db: ClawdeDatabase;
   try {
@@ -117,6 +270,11 @@ export async function runSmokeTest(options: SmokeTestOptions): Promise<number> {
   } finally {
     closeDb(db);
   }
+
+  checks.push(await checkWorkerDryRun());
+  checks.push(checkBwrapForSandboxAgents());
+  checks.push(checkOAuthExpiry());
+  checks.push(await checkSdkRealPing(options.includeSdkPing === true));
 
   if (options.receiverUrl !== undefined && options.receiverUrl.length > 0) {
     checks.push(await checkReceiverHealth(options.receiverUrl, options.receiverTimeoutMs ?? 2000));

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -108,6 +108,10 @@ Common options:
   --db <path>            DB path (default ~/.clawde/state.db ou env CLAWDE_DB)
   --output {text|json}   Formato de output (default text)
 
+Smoke options:
+  --receiver-url <url>   Inclui check GET /health do receiver
+  --include-sdk-ping     Faz ping real no SDK se CLAUDE_CODE_OAUTH_TOKEN presente
+
 Migrate options:
   --audit-sandbox        Em migrate status, audita agentes com network="allowlist"
   --fail-on-allowlist    Com --audit-sandbox, retorna exit 2 se houver achados
@@ -138,6 +142,9 @@ export async function runMain(argv: ReadonlyArray<string>): Promise<number> {
     };
     const recv = getFlag(parsed, "receiver-url");
     if (recv !== undefined) Object.assign(opts, { receiverUrl: recv });
+    if (parsed.flags["include-sdk-ping"] === true) {
+      Object.assign(opts, { includeSdkPing: true });
+    }
     return await runSmokeTest(opts);
   }
 

--- a/src/db/migrations/006_event_kind_smoke_ping.down.sql
+++ b/src/db/migrations/006_event_kind_smoke_ping.down.sql
@@ -1,0 +1,91 @@
+-- Migration 006 (DOWN) — remove smoke SDK ping event kinds.
+
+CREATE TABLE events_old (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           TEXT    NOT NULL DEFAULT (datetime('now')),
+  task_run_id  INTEGER REFERENCES task_runs(id) ON DELETE SET NULL,
+  session_id   TEXT    REFERENCES sessions(session_id) ON DELETE SET NULL,
+  trace_id     TEXT,
+  span_id      TEXT,
+  kind         TEXT    NOT NULL
+               CHECK (kind IN (
+                 'enqueue',
+                 'auth_fail',
+                 'rate_limit_hit',
+                 'dedup_skip',
+                 'task_deferred',
+                 'task_start',
+                 'task_finish',
+                 'task_fail',
+                 'lease_expired',
+                 'quarantine_enter',
+                 'quarantine_exit',
+                 'claude_invocation_start',
+                 'claude_invocation_end',
+                 'tool_use',
+                 'tool_result',
+                 'tool_blocked',
+                 'compact_triggered',
+                 'quota_threshold_crossed',
+                 'quota_reset',
+                 'peak_multiplier_applied',
+                 'quota_429_observed',
+                 'oauth_refresh_attempt',
+                 'oauth_refresh_success',
+                 'oauth_expiry_warning',
+                 'auth.telegram_reject',
+                 'auth.telegram_user_blocked',
+                 'sandbox_init',
+                 'sandbox_violation',
+                 'migration_start',
+                 'migration_end',
+                 'migration_fail',
+                 'maintenance_start',
+                 'maintenance_end',
+                 'prompt_guard_alert',
+                 'panic_stop',
+                 'hook_error',
+                 'hook_timeout',
+                 'lesson',
+                 'reflection_start',
+                 'reflection_end',
+                 'review.implementer.start',
+                 'review.implementer.end',
+                 'review.spec.start',
+                 'review.spec.verdict',
+                 'review.quality.start',
+                 'review.quality.verdict',
+                 'review.pipeline.complete',
+                 'review.pipeline.exhausted',
+                 'agent_invalid',
+                 'sdk_auth_error',
+                 'sdk_network_error'
+               )),
+  payload      TEXT    NOT NULL DEFAULT '{}'
+               CHECK (json_valid(payload))
+);
+
+INSERT INTO events_old
+SELECT *
+FROM events
+WHERE kind NOT IN ('smoke.sdk_real_ping_ok', 'smoke.sdk_real_ping_fail');
+
+DROP TABLE events;
+ALTER TABLE events_old RENAME TO events;
+
+CREATE INDEX idx_events_task_ts ON events(task_run_id, ts);
+CREATE INDEX idx_events_trace ON events(trace_id) WHERE trace_id IS NOT NULL;
+CREATE INDEX idx_events_kind_ts ON events(kind, ts);
+
+CREATE TRIGGER events_no_update
+BEFORE UPDATE ON events
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only');
+END;
+
+CREATE TRIGGER events_no_delete
+BEFORE DELETE ON events
+WHEN (SELECT COUNT(*) FROM _retention_grant) = 0
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only outside retention job');
+END;

--- a/src/db/migrations/006_event_kind_smoke_ping.up.sql
+++ b/src/db/migrations/006_event_kind_smoke_ping.up.sql
@@ -1,0 +1,93 @@
+-- Migration 006 (UP) — add smoke SDK ping event kinds.
+-- P3.5 T-121: supports `smoke.sdk_real_ping_ok` and `smoke.sdk_real_ping_fail`.
+
+CREATE TABLE events_new (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           TEXT    NOT NULL DEFAULT (datetime('now')),
+  task_run_id  INTEGER REFERENCES task_runs(id) ON DELETE SET NULL,
+  session_id   TEXT    REFERENCES sessions(session_id) ON DELETE SET NULL,
+  trace_id     TEXT,
+  span_id      TEXT,
+  kind         TEXT    NOT NULL
+               CHECK (kind IN (
+                 'enqueue',
+                 'auth_fail',
+                 'rate_limit_hit',
+                 'dedup_skip',
+                 'task_deferred',
+                 'task_start',
+                 'task_finish',
+                 'task_fail',
+                 'lease_expired',
+                 'quarantine_enter',
+                 'quarantine_exit',
+                 'claude_invocation_start',
+                 'claude_invocation_end',
+                 'tool_use',
+                 'tool_result',
+                 'tool_blocked',
+                 'compact_triggered',
+                 'quota_threshold_crossed',
+                 'quota_reset',
+                 'peak_multiplier_applied',
+                 'quota_429_observed',
+                 'oauth_refresh_attempt',
+                 'oauth_refresh_success',
+                 'oauth_expiry_warning',
+                 'auth.telegram_reject',
+                 'auth.telegram_user_blocked',
+                 'sandbox_init',
+                 'sandbox_violation',
+                 'migration_start',
+                 'migration_end',
+                 'migration_fail',
+                 'maintenance_start',
+                 'maintenance_end',
+                 'smoke.sdk_real_ping_ok',
+                 'smoke.sdk_real_ping_fail',
+                 'prompt_guard_alert',
+                 'panic_stop',
+                 'hook_error',
+                 'hook_timeout',
+                 'lesson',
+                 'reflection_start',
+                 'reflection_end',
+                 'review.implementer.start',
+                 'review.implementer.end',
+                 'review.spec.start',
+                 'review.spec.verdict',
+                 'review.quality.start',
+                 'review.quality.verdict',
+                 'review.pipeline.complete',
+                 'review.pipeline.exhausted',
+                 'agent_invalid',
+                 'sdk_auth_error',
+                 'sdk_network_error'
+               )),
+  payload      TEXT    NOT NULL DEFAULT '{}'
+               CHECK (json_valid(payload))
+);
+
+INSERT INTO events_new
+SELECT *
+FROM events;
+
+DROP TABLE events;
+ALTER TABLE events_new RENAME TO events;
+
+CREATE INDEX idx_events_task_ts ON events(task_run_id, ts);
+CREATE INDEX idx_events_trace ON events(trace_id) WHERE trace_id IS NOT NULL;
+CREATE INDEX idx_events_kind_ts ON events(kind, ts);
+
+CREATE TRIGGER events_no_update
+BEFORE UPDATE ON events
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only');
+END;
+
+CREATE TRIGGER events_no_delete
+BEFORE DELETE ON events
+WHEN (SELECT COUNT(*) FROM _retention_grant) = 0
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only outside retention job');
+END;

--- a/src/domain/event.ts
+++ b/src/domain/event.ts
@@ -45,6 +45,8 @@ export const EVENT_KIND_VALUES = [
   "migration_fail",
   "maintenance_start",
   "maintenance_end",
+  "smoke.sdk_real_ping_ok",
+  "smoke.sdk_real_ping_fail",
   // security
   "prompt_guard_alert",
   "panic_stop",

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -29,6 +29,10 @@ export function parseMaxTasks(argv: ReadonlyArray<string>, fallback = DEFAULT_MA
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+export function parseDryRun(argv: ReadonlyArray<string>): boolean {
+  return argv.includes("--dry-run");
+}
+
 export type LoopExitReason = "empty" | "deferred" | "max_tasks";
 
 export interface LoopResult {
@@ -104,6 +108,25 @@ export async function bootstrap(
       cleaned_orphans: reconcileResult.cleanedOrphans,
     });
     const maxTasks = parseMaxTasks(argv);
+    const dryRun = parseDryRun(argv);
+    const queueSize = tasksRepo.findPending(1000).length;
+    const quotaState = quotaTracker.currentWindow().state;
+    logger.info("worker bootstrap state", {
+      dry_run: dryRun,
+      agents_loaded: agentDefs.length,
+      queue_size: queueSize,
+      quota_state: quotaState,
+    });
+
+    if (dryRun) {
+      logger.info("worker dry-run complete", {
+        agents_loaded: agentDefs.length,
+        queue_size: queueSize,
+        quota_state: quotaState,
+      });
+      return;
+    }
+
     const loop = await runProcessLoop(
       {
         tasksRepo,

--- a/tests/integration/smoke-test.test.ts
+++ b/tests/integration/smoke-test.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runSmokeTest } from "@clawde/cli/commands/smoke-test";
@@ -34,12 +34,22 @@ function captureOutput(fn: () => Promise<number> | number): Promise<{
 describe("cli/smoke-test", () => {
   let dir: string;
   let dbPath: string;
+  let prevConfigEnv: string | undefined;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "clawde-smoke-"));
     dbPath = join(dir, "state.db");
+    const configPath = join(dir, "clawde.toml");
+    writeFileSync(configPath, `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`, "utf-8");
+    prevConfigEnv = process.env.CLAWDE_CONFIG;
+    process.env.CLAWDE_CONFIG = configPath;
   });
   afterEach(() => {
+    if (prevConfigEnv !== undefined) {
+      process.env.CLAWDE_CONFIG = prevConfigEnv;
+    } else {
+      process.env.CLAWDE_CONFIG = undefined;
+    }
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -52,6 +62,8 @@ describe("cli/smoke-test", () => {
     expect(exit).toBe(0);
     expect(stdout).toContain("[OK ] db.integrity_check");
     expect(stdout).toContain("[OK ] db.migrations");
+    expect(stdout).toContain("[OK ] worker.dry_run");
+    expect(stdout).toContain("[OK ] auth.oauth_expiry");
     expect(stdout).toContain("overall: OK");
   });
 
@@ -76,7 +88,7 @@ describe("cli/smoke-test", () => {
     expect(exit).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.checks).toHaveLength(2);
+    expect(parsed.checks.length).toBeGreaterThanOrEqual(5);
     expect(parsed.checks[0].name).toBe("db.integrity_check");
   });
 
@@ -103,5 +115,23 @@ describe("cli/smoke-test", () => {
     );
     expect(exit).toBe(1);
     expect(stdout).toContain("[FAIL] receiver.health");
+  });
+
+  test("--include-sdk-ping sem token não falha (skip)", async () => {
+    const db = openDb(dbPath);
+    applyPending(db, defaultMigrationsDir());
+    closeDb(db);
+
+    const envBak = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = undefined;
+    try {
+      const { exit, stdout } = await captureOutput(() =>
+        runSmokeTest({ dbPath, format: "text", includeSdkPing: true }),
+      );
+      expect(exit).toBe(0);
+      expect(stdout).toContain("[OK ] sdk.real_ping: skipped (token missing)");
+    } finally {
+      if (envBak !== undefined) process.env.CLAUDE_CODE_OAUTH_TOKEN = envBak;
+    }
   });
 });

--- a/tests/integration/smoke-test.test.ts
+++ b/tests/integration/smoke-test.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runSmokeTest } from "@clawde/cli/commands/smoke-test";
@@ -35,6 +35,7 @@ describe("cli/smoke-test", () => {
   let dir: string;
   let dbPath: string;
   let prevConfigEnv: string | undefined;
+  let prevHomeEnv: string | undefined;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "clawde-smoke-"));
@@ -42,6 +43,7 @@ describe("cli/smoke-test", () => {
     const configPath = join(dir, "clawde.toml");
     writeFileSync(configPath, `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`, "utf-8");
     prevConfigEnv = process.env.CLAWDE_CONFIG;
+    prevHomeEnv = process.env.HOME;
     process.env.CLAWDE_CONFIG = configPath;
   });
   afterEach(() => {
@@ -49,6 +51,11 @@ describe("cli/smoke-test", () => {
       process.env.CLAWDE_CONFIG = prevConfigEnv;
     } else {
       process.env.CLAWDE_CONFIG = undefined;
+    }
+    if (prevHomeEnv !== undefined) {
+      process.env.HOME = prevHomeEnv;
+    } else {
+      process.env.HOME = undefined;
     }
     rmSync(dir, { recursive: true, force: true });
   });
@@ -132,6 +139,28 @@ describe("cli/smoke-test", () => {
       expect(stdout).toContain("[OK ] sdk.real_ping: skipped (token missing)");
     } finally {
       if (envBak !== undefined) process.env.CLAUDE_CODE_OAUTH_TOKEN = envBak;
+    }
+  });
+
+  test("não acopla em config global implícita do HOME", async () => {
+    const db = openDb(dbPath);
+    applyPending(db, defaultMigrationsDir());
+    closeDb(db);
+
+    const fakeHome = mkdtempSync(join(tmpdir(), "clawde-smoke-home-"));
+    try {
+      const badConfigDir = join(fakeHome, ".clawde", "config");
+      mkdirSync(badConfigDir, { recursive: true });
+      writeFileSync(join(badConfigDir, "clawde.toml"), "clawde = [broken", "utf-8");
+      process.env.HOME = fakeHome;
+      process.env.CLAWDE_CONFIG = undefined;
+
+      const { exit, stdout } = await captureOutput(() => runSmokeTest({ dbPath, format: "text" }));
+      expect(exit).toBe(0);
+      expect(stdout).toContain("[OK ] worker.dry_run");
+      expect(stdout).toContain("overall: OK");
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/domain/event.test.ts
+++ b/tests/unit/domain/event.test.ts
@@ -36,6 +36,11 @@ describe("domain/event EVENT_KIND_VALUES", () => {
     expect(EVENT_KIND_VALUES).toContain("sandbox_violation");
   });
 
+  test("contains smoke sdk ping kinds", () => {
+    expect(EVENT_KIND_VALUES).toContain("smoke.sdk_real_ping_ok");
+    expect(EVENT_KIND_VALUES).toContain("smoke.sdk_real_ping_fail");
+  });
+
   test("contains learning kinds (ADR 0009)", () => {
     expect(EVENT_KIND_VALUES).toContain("lesson");
     expect(EVENT_KIND_VALUES).toContain("reflection_start");

--- a/tests/unit/worker/main.parse-max-tasks.test.ts
+++ b/tests/unit/worker/main.parse-max-tasks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseMaxTasks } from "@clawde/worker/main";
+import { parseDryRun, parseMaxTasks } from "@clawde/worker/main";
 
 describe("worker/main parseMaxTasks", () => {
   test("default 50 quando flag ausente", () => {
@@ -25,5 +25,12 @@ describe("worker/main parseMaxTasks", () => {
   test("respeita fallback custom", () => {
     expect(parseMaxTasks([], 25)).toBe(25);
     expect(parseMaxTasks(["--max-tasks", "abc"], 25)).toBe(25);
+  });
+
+  test("parseDryRun detecta --dry-run", () => {
+    expect(parseDryRun([])).toBe(false);
+    expect(parseDryRun(["--max-tasks", "5"])).toBe(false);
+    expect(parseDryRun(["--dry-run"])).toBe(true);
+    expect(parseDryRun(["--foo", "1", "--dry-run"])).toBe(true);
   });
 });


### PR DESCRIPTION
Closes sub-phase P3.5 in EXECUTION_BACKLOG.md.

## Tasks included
- T-116: criar systemd smoke service
- T-117: estender smoke-test com check de worker dry-run
- T-118: adicionar --dry-run no worker bootstrap
- T-119: verificar presença de bwrap por perfil carregado
- T-120: checar expiração de OAuth no smoke
- T-121: opcional sdk real ping + persistência de eventos de outcome

## What changed
Atualizei o serviço de smoke para rodar o comando de smoke-test, expandi os checks do comando (worker dry-run, bwrap, oauth e ping opcional), e adicionei persistência de eventos específicos para sucesso/falha de sdk real ping. Também incluí migration para aceitar os novos event kinds.

## Acceptance criteria validated
- [x] T-116
- [x] T-117
- [x] T-118
- [x] T-119
- [x] T-120
- [x] T-121

## CI
- [x] bun run typecheck clean
- [x] bun run lint clean (2 warnings preexistentes de console.warn em testes bootstrap)
- [x] bun test focal passing (smoke/integration + unit/domain + migrations)
- [ ] bun test full suite estável no ambiente local (há falhas preexistentes por EADDRINUSE + flaky findExpiredLeases)

## Notes for reviewer
- O full suite local atual falha fora do escopo desta sub-fase por portas já em uso em testes E2E/receiver.
- Para o escopo P3.5, os testes focais da mudança passam 100%.