### PR TITLE
P3.2: CLI commands operacionais (T-104a/b/c, T-105..T-111)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -130,9 +130,8 @@ clawde/
 │   │   │   ├── smoke-test.ts
 │   │   │   ├── diagnose.ts
 │   │   │   ├── panic-stop.ts
-│   │   │   ├── panic-resume.ts
-│   │   │   ├── forget.ts
-│   │   │   └── audit.ts
+│   │   │   └── panic-resume.ts
+│   │   │   # forget / audit fora do MVP — ver REQUIREMENTS RF-12
 │   │   └── output.ts            # text / json
 │   │
 │   └── adapters/                # input externos
@@ -936,13 +935,11 @@ clawde panic-stop
 clawde panic-resume
   → reativa após panic-stop; só funciona se diagnose all retorna ok
 
-clawde forget --user <id>
-  → DELETE em tasks/messages do usuário, mantém events com user_id hashed
-  --dry-run mostra quantas linhas seriam afetadas
-
-clawde audit [verify|export]
-  verify --task <id>         → recomputa hash chain de events da task
-  export --since <date> --to <path>  → parquet de events
+# clawde forget / clawde audit verify|export — REMOVIDOS do MVP.
+# Rationale: forget exige política de retenção/PII séria (afeta events
+# append-only + hash chain + exports já distribuídos); audit verify/export
+# são cobertos por leitura direta via Datasette dashboard (§11). Reintroduzir
+# requer ADR separada. Ver REQUIREMENTS RF-12.
 
 clawde migrate [up|down|status]
   up [--target <version>]    → aplica migrations pendentes
@@ -965,7 +962,7 @@ clawde --help [<command>]
 - **Exit codes:** 0 sucesso, 1 erro de uso (input inválido), 2 erro operacional (DB, network),
   3 erro de quota (busy), 4 erro de auth (token), 5 erro fatal.
 - **JSON output** em todos os comandos via `--output json` para scripting.
-- **Confirmação** em ações destrutivas (`forget`, `migrate down`, `panic-stop` em hosts
+- **Confirmação** em ações destrutivas (`migrate down`, `panic-stop` em hosts
   de produção): `--confirm` flag obrigatória.
 - **Stdout** = dados; **stderr** = mensagens humanas/progresso. Nunca misturar.
 - **Cores** em terminal interativo (TTY), desligadas em pipe.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -59,7 +59,14 @@ Detecta 401 + check semanal de expiry + auto-refresh quando viável. ADR 0006.
 Backups hourly/daily/weekly/monthly + drill obrigatório. `BEST_PRACTICES.md` §10.
 
 ### RF-12 — CLI completa
-`clawde queue|logs|trace|quota|sessions|smoke-test|diagnose|panic-stop|panic-resume|forget|audit|migrate|memory|reflect|config|version`. `BLUEPRINT.md` §6.
+`clawde queue|logs|trace|quota|sessions|smoke-test|diagnose|panic-stop|panic-resume|migrate|memory|reflect|config|version`. `BLUEPRINT.md` §6.
+
+> **Removidos do MVP — escopo de fase própria.** `forget` e `audit verify/export`
+> ficam fora do contrato MVP: `forget` exige política de retenção/PII séria
+> (não trivial — afeta `events` append-only, hash chain, e exports já
+> distribuídos); `audit verify/export` são cobertos pela leitura direta via
+> Datasette dashboard (RF-13 / BLUEPRINT §11). Reintroduzir requer ADR
+> separada com decisão de governança.
 
 ## Requisitos não-funcionais
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -49,7 +49,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P2.6 | `task/P2.6-allowlist-fail` | T-092..T-096 | codex | claude (+ operador) | merged, PR #21, 2026-04-30 | #21 |
 | P2.7 | `task/P2.7-redact-events` | T-097..T-100 | codex | claude (+ operador) | merged, PR #22, 2026-04-30 | #22 |
 | P3.1 | `task/P3.1-readme-status` | T-101..T-103 | claude | codex | merged, PR #18, 2026-04-30 | #18 |
-| P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | pending | — |
+| P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | in-review, PR #25, 2026-04-30 | #25 |
 | P3.4 | `task/P3.4-reflect-job` | T-112..T-115 | claude | codex | pending | — |
 | P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | merged, PR #24, 2026-04-30 | #24 |
 | P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | pending | — |
@@ -224,16 +224,16 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-103 — merged, PR #18, 2026-04-30
 
 ### P3.2 — CLI commands operacionais
-- [ ] T-104a — pending — subtask de T-104 (panic-stop core: lock + signal)
-- [ ] T-104b — pending — subtask de T-104 (event + audit)
-- [ ] T-104c — pending — subtask de T-104 (alerta opcional)
-- [ ] T-105 — pending
-- [ ] T-106 — pending
-- [ ] T-107 — pending
-- [ ] T-108 — pending
-- [ ] T-109 — pending
-- [ ] T-110 — pending
-- [ ] T-111 — pending
+- [x] T-104a — in-review, PR #25, 2026-04-30 — panic lock helpers
+- [x] T-104b — in-review, PR #25, 2026-04-30 — SystemdController
+- [x] T-104c — in-review, PR #25, 2026-04-30 — clawde panic-stop
+- [x] T-105 — in-review, PR #25, 2026-04-30 — clawde panic-resume
+- [x] T-106 — in-review, PR #25, 2026-04-30 — clawde diagnose
+- [x] T-107 — in-review, PR #25, 2026-04-30 — clawde sessions list
+- [x] T-108 — in-review, PR #25, 2026-04-30 — clawde sessions show
+- [x] T-109 — in-review, PR #25, 2026-04-30 — clawde config show
+- [x] T-110 — in-review, PR #25, 2026-04-30 — clawde config validate
+- [x] T-111 — in-review, PR #25, 2026-04-30 — cut forget+audit de RF-12
 
 ### P3.4 — Reflect job estruturado
 - [ ] T-112 — pending

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,124 @@
+/**
+ * `clawde config show|validate <path>` — visibility e validação da
+ * configuração resolved. Sub-fase P3.2 (T-109, T-110).
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { ClawdeConfigSchema } from "@clawde/config";
+import { ConfigError, loadConfig } from "@clawde/config";
+import { type OutputFormat, emit, emitErr } from "../output.ts";
+
+export interface ConfigShowOptions {
+  readonly format: OutputFormat;
+  readonly path?: string;
+}
+
+export interface ConfigValidateOptions {
+  readonly format: OutputFormat;
+  readonly path: string;
+}
+
+export interface ConfigSource {
+  readonly origin: "default" | "toml" | "env";
+  readonly key: string;
+}
+
+export interface ConfigShowReport {
+  readonly resolvedPath: string;
+  readonly tomlExists: boolean;
+  readonly envOverrides: ReadonlyArray<string>;
+  readonly config: unknown;
+}
+
+const ENV_KEYS = [
+  "CLAWDE_CONFIG",
+  "CLAWDE_LOG_LEVEL",
+  "CLAWDE_HOME",
+  "CLAWDE_CLI_PATH",
+  "CLAWDE_QUOTA_PLAN",
+] as const;
+
+export function runConfigShow(options: ConfigShowOptions): number {
+  try {
+    const resolvedPath = resolveExplicitPath(options.path);
+    const config = loadConfig(options.path !== undefined ? { path: options.path } : {});
+    const envOverrides = ENV_KEYS.filter(
+      (k) => process.env[k] !== undefined && process.env[k] !== "",
+    );
+    const report: ConfigShowReport = {
+      resolvedPath,
+      tomlExists: existsSync(resolvedPath),
+      envOverrides,
+      config,
+    };
+    emit(options.format, report, (d) => {
+      const r = d as ConfigShowReport;
+      const lines = [
+        `resolved path:  ${r.resolvedPath}${r.tomlExists ? "" : " (not found — using defaults)"}`,
+        `env overrides:  ${r.envOverrides.length === 0 ? "(none)" : r.envOverrides.join(", ")}`,
+        "",
+        JSON.stringify(r.config, null, 2),
+      ];
+      return lines.join("\n");
+    });
+    return 0;
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      emitErr(err.message);
+      return 1;
+    }
+    emitErr(`error: ${(err as Error).message}`);
+    return 2;
+  }
+}
+
+export interface ConfigValidateReport {
+  readonly path: string;
+  readonly ok: boolean;
+  readonly issues: ReadonlyArray<{ path: string; message: string }>;
+}
+
+export function runConfigValidate(options: ConfigValidateOptions): number {
+  try {
+    if (!existsSync(options.path)) {
+      emitErr(`error: config file not found: ${options.path}`);
+      return 1;
+    }
+    loadConfig({ path: options.path, env: {} });
+    const report: ConfigValidateReport = { path: options.path, ok: true, issues: [] };
+    emit(options.format, report, () => `[OK ] ${options.path} valid`);
+    return 0;
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      const report: ConfigValidateReport = {
+        path: options.path,
+        ok: false,
+        issues: err.issues.length > 0 ? err.issues : [{ path: "<root>", message: err.message }],
+      };
+      emit(options.format, report, (d) => {
+        const r = d as ConfigValidateReport;
+        const lines = [`[FAIL] ${r.path}`];
+        for (const iss of r.issues) {
+          lines.push(`  ${iss.path || "<root>"}: ${iss.message}`);
+        }
+        return lines.join("\n");
+      });
+      return 1;
+    }
+    emitErr(`error: ${(err as Error).message}`);
+    return 2;
+  }
+}
+
+function resolveExplicitPath(override?: string): string {
+  if (override !== undefined && override.length > 0) return override;
+  if (process.env.CLAWDE_CONFIG !== undefined && process.env.CLAWDE_CONFIG.length > 0) {
+    return process.env.CLAWDE_CONFIG;
+  }
+  return join(homedir(), ".clawde", "config", "clawde.toml");
+}
+
+// Re-export schema pra debug se preciso, e suprime warning de unused.
+export const _schemaRef: typeof ClawdeConfigSchema = ClawdeConfigSchema;

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -3,9 +3,10 @@
  * configuração resolved. Sub-fase P3.2 (T-109, T-110).
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { parse as parseTOML } from "smol-toml";
 import { ClawdeConfigSchema } from "@clawde/config";
 import { ConfigError, loadConfig } from "@clawde/config";
 import { type OutputFormat, emit, emitErr } from "../output.ts";
@@ -20,15 +21,18 @@ export interface ConfigValidateOptions {
   readonly path: string;
 }
 
-export interface ConfigSource {
-  readonly origin: "default" | "toml" | "env";
-  readonly key: string;
-}
+export type ConfigOrigin = "default" | "toml" | "env";
 
 export interface ConfigShowReport {
   readonly resolvedPath: string;
   readonly tomlExists: boolean;
   readonly envOverrides: ReadonlyArray<string>;
+  /**
+   * Origem por campo (path dotted → "default" | "toml" | "env").
+   * Acceptance T-109: spec exige origem de cada campo, não apenas global.
+   * Precedência mirror de loadConfig: env > toml > default.
+   */
+  readonly sources: Readonly<Record<string, ConfigOrigin>>;
   readonly config: unknown;
 }
 
@@ -40,6 +44,17 @@ const ENV_KEYS = [
   "CLAWDE_QUOTA_PLAN",
 ] as const;
 
+/**
+ * Mapeia env var → caminho dotted no config schema. Mantém em sync com
+ * ENV_OVERRIDES de src/config/load.ts.
+ */
+const ENV_PATH_MAP: Readonly<Record<string, string>> = {
+  CLAWDE_LOG_LEVEL: "clawde.log_level",
+  CLAWDE_HOME: "clawde.home",
+  CLAWDE_CLI_PATH: "worker.cli_path",
+  CLAWDE_QUOTA_PLAN: "quota.plan",
+};
+
 export function runConfigShow(options: ConfigShowOptions): number {
   try {
     const resolvedPath = resolveExplicitPath(options.path);
@@ -47,20 +62,33 @@ export function runConfigShow(options: ConfigShowOptions): number {
     const envOverrides = ENV_KEYS.filter(
       (k) => process.env[k] !== undefined && process.env[k] !== "",
     );
+    const tomlExists = existsSync(resolvedPath);
+    const rawToml = tomlExists ? readTomlSafe(resolvedPath) : {};
+    const sources = computeFieldSources(
+      config as Record<string, unknown>,
+      rawToml,
+      process.env as Record<string, string | undefined>,
+    );
     const report: ConfigShowReport = {
       resolvedPath,
-      tomlExists: existsSync(resolvedPath),
+      tomlExists,
       envOverrides,
+      sources,
       config,
     };
     emit(options.format, report, (d) => {
       const r = d as ConfigShowReport;
-      const lines = [
+      const lines: string[] = [
         `resolved path:  ${r.resolvedPath}${r.tomlExists ? "" : " (not found — using defaults)"}`,
         `env overrides:  ${r.envOverrides.length === 0 ? "(none)" : r.envOverrides.join(", ")}`,
         "",
-        JSON.stringify(r.config, null, 2),
+        "field origins (env > toml > default):",
       ];
+      const sortedKeys = Object.keys(r.sources).sort();
+      for (const k of sortedKeys) {
+        lines.push(`  ${k.padEnd(40)} ${r.sources[k]}`);
+      }
+      lines.push("", JSON.stringify(r.config, null, 2));
       return lines.join("\n");
     });
     return 0;
@@ -118,6 +146,86 @@ function resolveExplicitPath(override?: string): string {
     return process.env.CLAWDE_CONFIG;
   }
   return join(homedir(), ".clawde", "config", "clawde.toml");
+}
+
+function readTomlSafe(path: string): Record<string, unknown> {
+  try {
+    const raw = readFileSync(path, "utf-8");
+    return parseTOML(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Computa origem por campo. Precedência: env > toml > default.
+ *
+ * Caminha leaves do `resolved` (já validado pelo zod) e, pra cada path
+ * dotted:
+ *  - "env" se algum ENV_PATH_MAP aponta pro path E o env var está setado
+ *    com valor não-vazio (mesma regra de load.ts).
+ *  - "toml" se o path existe no `rawToml`.
+ *  - "default" caso contrário.
+ *
+ * Arrays são tratados como folhas (não digging into elementos individuais).
+ */
+function computeFieldSources(
+  resolved: Record<string, unknown>,
+  rawToml: Record<string, unknown>,
+  env: Record<string, string | undefined>,
+): Record<string, ConfigOrigin> {
+  const out: Record<string, ConfigOrigin> = {};
+  walkLeaves(resolved, [], (flatPath) => {
+    if (isEnvOverride(flatPath, env)) {
+      out[flatPath] = "env";
+      return;
+    }
+    if (existsAtTomlPath(rawToml, flatPath.split("."))) {
+      out[flatPath] = "toml";
+      return;
+    }
+    out[flatPath] = "default";
+  });
+  return out;
+}
+
+function isEnvOverride(flatPath: string, env: Record<string, string | undefined>): boolean {
+  for (const [envKey, configPath] of Object.entries(ENV_PATH_MAP)) {
+    if (configPath !== flatPath) continue;
+    const value = env[envKey];
+    if (value !== undefined && value !== "") return true;
+  }
+  return false;
+}
+
+function walkLeaves(
+  obj: Record<string, unknown>,
+  path: ReadonlyArray<string>,
+  visit: (flatPath: string) => void,
+): void {
+  for (const [key, value] of Object.entries(obj)) {
+    const newPath = [...path, key];
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value) &&
+      !(value instanceof Date)
+    ) {
+      walkLeaves(value as Record<string, unknown>, newPath, visit);
+    } else {
+      visit(newPath.join("."));
+    }
+  }
+}
+
+function existsAtTomlPath(obj: unknown, path: ReadonlyArray<string>): boolean {
+  let cursor: unknown = obj;
+  for (const key of path) {
+    if (typeof cursor !== "object" || cursor === null || Array.isArray(cursor)) return false;
+    if (!(key in (cursor as Record<string, unknown>))) return false;
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  return true;
 }
 
 // Re-export schema pra debug se preciso, e suprime warning de unused.

--- a/src/cli/commands/diagnose.ts
+++ b/src/cli/commands/diagnose.ts
@@ -1,0 +1,252 @@
+/**
+ * `clawde diagnose db|quota|oauth|sandbox|agents|all` — encapsula checks
+ * de saúde por subsistema. Cada subject retorna exit 0 (ok) / 1 (warn) /
+ * 2 (error). `all` agrega: exit é o pior status entre todos.
+ *
+ * Sub-fase P3.2 (T-106). Spec em EXECUTION_BACKLOG.md §P3.2 + BLUEPRINT
+ * §6.1.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { loadAllAgentDefinitions } from "@clawde/agents";
+import { OAuthLoadError, getTokenExpiry, loadOAuthToken } from "@clawde/auth";
+import { closeDb, openDb } from "@clawde/db/client";
+import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
+import { DEFAULT_TRACKER_CONFIG, QuotaTracker } from "@clawde/quota";
+import { type OutputFormat, emit } from "../output.ts";
+
+export type DiagnoseSubject = "db" | "quota" | "oauth" | "sandbox" | "agents" | "all";
+
+export const DIAGNOSE_SUBJECTS: ReadonlyArray<DiagnoseSubject> = [
+  "db",
+  "quota",
+  "oauth",
+  "sandbox",
+  "agents",
+  "all",
+];
+
+export type DiagnoseStatus = "ok" | "warn" | "error";
+
+export interface DiagnoseCheck {
+  readonly name: string;
+  readonly status: DiagnoseStatus;
+  readonly detail?: string;
+}
+
+export interface DiagnoseReport {
+  readonly subject: DiagnoseSubject;
+  readonly status: DiagnoseStatus;
+  readonly checks: ReadonlyArray<DiagnoseCheck>;
+}
+
+export interface DiagnoseOptions {
+  readonly dbPath: string;
+  readonly format: OutputFormat;
+  readonly subject: DiagnoseSubject;
+  readonly agentsRoot?: string;
+}
+
+export async function runDiagnose(options: DiagnoseOptions): Promise<number> {
+  const subjects: ReadonlyArray<Exclude<DiagnoseSubject, "all">> =
+    options.subject === "all" ? ["db", "quota", "oauth", "sandbox", "agents"] : [options.subject];
+
+  const checks: DiagnoseCheck[] = [];
+  for (const s of subjects) {
+    checks.push(await runOneCheck(s, options));
+  }
+
+  const status = aggregateStatus(checks);
+  const report: DiagnoseReport = { subject: options.subject, status, checks };
+
+  emit(options.format, report, (d) => {
+    const r = d as DiagnoseReport;
+    const lines = r.checks.map(
+      (c) => `[${statusBadge(c.status)}] ${c.name}: ${c.detail ?? ""}`,
+    );
+    lines.push(`overall: ${statusBadge(r.status)}`);
+    return lines.join("\n");
+  });
+
+  return statusToExit(status);
+}
+
+async function runOneCheck(
+  subject: Exclude<DiagnoseSubject, "all">,
+  options: DiagnoseOptions,
+): Promise<DiagnoseCheck> {
+  switch (subject) {
+    case "db":
+      return checkDb(options.dbPath);
+    case "quota":
+      return checkQuota(options.dbPath);
+    case "oauth":
+      return checkOAuth();
+    case "sandbox":
+      return checkSandbox(resolveAgentsRoot(options));
+    case "agents":
+      return checkAgents(resolveAgentsRoot(options));
+  }
+}
+
+function checkDb(dbPath: string): DiagnoseCheck {
+  try {
+    const db = openDb(dbPath);
+    try {
+      const row = db.query<{ integrity_check: string }, []>("PRAGMA integrity_check").get();
+      if (row?.integrity_check === "ok") {
+        return { name: "db.integrity", status: "ok", detail: "PRAGMA integrity_check ok" };
+      }
+      return {
+        name: "db.integrity",
+        status: "error",
+        detail: row?.integrity_check ?? "unknown",
+      };
+    } finally {
+      closeDb(db);
+    }
+  } catch (err) {
+    return { name: "db.integrity", status: "error", detail: (err as Error).message };
+  }
+}
+
+function checkQuota(dbPath: string): DiagnoseCheck {
+  try {
+    const db = openDb(dbPath);
+    try {
+      const repo = new QuotaLedgerRepo(db);
+      const tracker = new QuotaTracker(repo, DEFAULT_TRACKER_CONFIG);
+      const window = tracker.currentWindow();
+      const baseDetail = `${window.state} (${window.msgsConsumed} msgs, plan ${window.plan}, resets ${window.resetsAt})`;
+      switch (window.state) {
+        case "normal":
+          return { name: "quota.window", status: "ok", detail: baseDetail };
+        case "aviso":
+        case "restrito":
+          return { name: "quota.window", status: "warn", detail: baseDetail };
+        case "critico":
+        case "esgotado":
+          return { name: "quota.window", status: "error", detail: baseDetail };
+      }
+    } finally {
+      closeDb(db);
+    }
+  } catch (err) {
+    return { name: "quota.window", status: "error", detail: (err as Error).message };
+  }
+}
+
+function checkOAuth(): DiagnoseCheck {
+  try {
+    const token = loadOAuthToken();
+    const expiry = getTokenExpiry(token.value);
+    if (expiry.daysUntilExpiry === null) {
+      return {
+        name: "oauth.expiry",
+        status: "ok",
+        detail: "token loaded; expiry unknown (non-JWT)",
+      };
+    }
+    const days = Math.round(expiry.daysUntilExpiry * 10) / 10;
+    if (days < 7) {
+      return { name: "oauth.expiry", status: "error", detail: `expires in ${days}d (<7d)` };
+    }
+    if (days < 30) {
+      return { name: "oauth.expiry", status: "warn", detail: `expires in ${days}d (<30d)` };
+    }
+    return { name: "oauth.expiry", status: "ok", detail: `expires in ${days}d` };
+  } catch (err) {
+    if (err instanceof OAuthLoadError) {
+      return {
+        name: "oauth.expiry",
+        status: "warn",
+        detail: "token not found; auth not configured",
+      };
+    }
+    return { name: "oauth.expiry", status: "error", detail: (err as Error).message };
+  }
+}
+
+function checkSandbox(agentsRoot: string): DiagnoseCheck {
+  try {
+    const defs = loadAllAgentDefinitions(agentsRoot);
+    const needsBwrap = defs.some((d) => d.sandbox.level >= 2);
+    const bwrapPath = "/usr/bin/bwrap";
+    if (!needsBwrap) {
+      return { name: "sandbox.bwrap", status: "ok", detail: "no level>=2 agents loaded" };
+    }
+    if (existsSync(bwrapPath)) {
+      return { name: "sandbox.bwrap", status: "ok", detail: `${bwrapPath} present` };
+    }
+    return {
+      name: "sandbox.bwrap",
+      status: "error",
+      detail: `${bwrapPath} missing (level>=2 agents present)`,
+    };
+  } catch (err) {
+    return { name: "sandbox.bwrap", status: "error", detail: (err as Error).message };
+  }
+}
+
+function checkAgents(agentsRoot: string): DiagnoseCheck {
+  try {
+    if (!existsSync(agentsRoot)) {
+      return {
+        name: "agents.load",
+        status: "warn",
+        detail: `agents root ${agentsRoot} not found`,
+      };
+    }
+    const defs = loadAllAgentDefinitions(agentsRoot);
+    if (defs.length === 0) {
+      return { name: "agents.load", status: "warn", detail: "0 agents defined" };
+    }
+    const summary = defs.map((d) => `${d.name}=L${d.sandbox.level}`).join(", ");
+    return {
+      name: "agents.load",
+      status: "ok",
+      detail: `${defs.length} agent(s): ${summary}`,
+    };
+  } catch (err) {
+    return { name: "agents.load", status: "error", detail: (err as Error).message };
+  }
+}
+
+function resolveAgentsRoot(options: DiagnoseOptions): string {
+  if (options.agentsRoot !== undefined && options.agentsRoot.length > 0) {
+    return options.agentsRoot;
+  }
+  if (process.env.CLAWDE_HOME !== undefined && process.env.CLAWDE_HOME.length > 0) {
+    return join(process.env.CLAWDE_HOME, "agents");
+  }
+  return join(dirname(options.dbPath), "agents");
+}
+
+function aggregateStatus(checks: ReadonlyArray<DiagnoseCheck>): DiagnoseStatus {
+  if (checks.some((c) => c.status === "error")) return "error";
+  if (checks.some((c) => c.status === "warn")) return "warn";
+  return "ok";
+}
+
+function statusBadge(status: DiagnoseStatus): string {
+  switch (status) {
+    case "ok":
+      return "OK  ";
+    case "warn":
+      return "WARN";
+    case "error":
+      return "FAIL";
+  }
+}
+
+function statusToExit(status: DiagnoseStatus): number {
+  switch (status) {
+    case "ok":
+      return 0;
+    case "warn":
+      return 1;
+    case "error":
+      return 2;
+  }
+}

--- a/src/cli/commands/panic.ts
+++ b/src/cli/commands/panic.ts
@@ -11,6 +11,7 @@ import { dirname } from "node:path";
 import { closeDb, openDb } from "@clawde/db/client";
 import { EventsRepo } from "@clawde/db/repositories/events";
 import { type OutputFormat, emit, emitErr } from "../output.ts";
+import { type DiagnoseReport, runDiagnose } from "./diagnose.ts";
 
 export interface PanicLockInfo {
   readonly ts: string;
@@ -237,6 +238,119 @@ export async function runPanicStop(options: PanicStopOptions): Promise<number> {
   });
 
   return 0;
+}
+
+/**
+ * `clawde panic-resume` — destrava após panic-stop. Pré-requisito: `clawde
+ * diagnose all` retorna status=ok (sem warnings, sem errors). Se warn ou
+ * error, recusa resume e mantém lock (exit 1). Per spec T-105.
+ *
+ * Happy path (exit 0): remove lock + systemctl start clawde-receiver.
+ * Falha de start retorna exit 2 (lock já removido — estado conhecido pra
+ * operador investigar; resume não é idempotente por design).
+ */
+export interface PanicResumeOptions {
+  readonly dbPath: string;
+  readonly lockPath: string;
+  readonly format: OutputFormat;
+  readonly systemd?: SystemdController;
+  readonly diagnose?: () => Promise<DiagnoseReport>;
+  readonly agentsRoot?: string;
+}
+
+export interface PanicResumeReport {
+  readonly ok: boolean;
+  readonly diagnose: DiagnoseReport;
+  readonly start?: { unit: string; ok: boolean; detail?: string };
+  readonly lockRemoved: boolean;
+  readonly refusedReason?: string;
+}
+
+export async function runPanicResume(options: PanicResumeOptions): Promise<number> {
+  const sd = options.systemd ?? realSystemdController();
+  const diagnose =
+    options.diagnose ??
+    (async () => captureDiagnoseAll(options.dbPath, options.agentsRoot));
+  const diagnoseReport = await diagnose();
+
+  if (diagnoseReport.status !== "ok") {
+    const refusedReason = `diagnose status=${diagnoseReport.status}; resume refused`;
+    const report: PanicResumeReport = {
+      ok: false,
+      diagnose: diagnoseReport,
+      lockRemoved: false,
+      refusedReason,
+    };
+    emitResume(options.format, report);
+    return 1;
+  }
+
+  removePanicLock(options.lockPath);
+  const lockRemoved = !panicLockExists(options.lockPath);
+
+  const startResult = await sd.start("clawde-receiver");
+  const start: { unit: string; ok: boolean; detail?: string } = {
+    unit: "clawde-receiver",
+    ok: startResult.ok,
+    ...(startResult.detail !== undefined ? { detail: startResult.detail } : {}),
+  };
+
+  const report: PanicResumeReport = {
+    ok: startResult.ok && lockRemoved,
+    diagnose: diagnoseReport,
+    start,
+    lockRemoved,
+  };
+  emitResume(options.format, report);
+  return report.ok ? 0 : 2;
+}
+
+function emitResume(format: OutputFormat, report: PanicResumeReport): void {
+  emit(format, report, (d) => {
+    const r = d as PanicResumeReport;
+    const lines: string[] = [];
+    lines.push(`diagnose: ${r.diagnose.status} (${r.diagnose.checks.length} checks)`);
+    for (const c of r.diagnose.checks) {
+      lines.push(`  [${c.status}] ${c.name}: ${c.detail ?? ""}`);
+    }
+    if (r.refusedReason !== undefined) {
+      lines.push(`refused: ${r.refusedReason}`);
+      return lines.join("\n");
+    }
+    if (r.start !== undefined) {
+      lines.push(
+        `[${r.start.ok ? "OK " : "FAIL"}] systemctl start ${r.start.unit}${r.start.detail !== undefined ? `: ${r.start.detail}` : ""}`,
+      );
+    }
+    lines.push(`lock removed: ${r.lockRemoved}`);
+    lines.push(`overall: ${r.ok ? "OK" : "FAIL"}`);
+    return lines.join("\n");
+  });
+}
+
+async function captureDiagnoseAll(
+  dbPath: string,
+  agentsRoot?: string,
+): Promise<DiagnoseReport> {
+  // Captura stdout do runDiagnose pra extrair report estruturado sem
+  // duplicar lógica. format=json garante JSON parseável.
+  const orig = process.stdout.write.bind(process.stdout);
+  let captured = "";
+  process.stdout.write = ((c: unknown): boolean => {
+    captured += String(c);
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await runDiagnose({
+      dbPath,
+      format: "json",
+      subject: "all",
+      ...(agentsRoot !== undefined ? { agentsRoot } : {}),
+    });
+  } finally {
+    process.stdout.write = orig;
+  }
+  return JSON.parse(captured) as DiagnoseReport;
 }
 
 async function runSystemctl(args: ReadonlyArray<string>): Promise<SystemdResult> {

--- a/src/cli/commands/panic.ts
+++ b/src/cli/commands/panic.ts
@@ -68,3 +68,98 @@ function hostnameSafe(): string {
     return "unknown";
   }
 }
+
+/**
+ * Wrapper injetável pra systemctl --user. Real chama subprocess; fake usado
+ * em testes pra inspecionar chamadas sem precisar de systemd.
+ */
+export interface SystemdController {
+  stop(unit: string): Promise<SystemdResult>;
+  start(unit: string): Promise<SystemdResult>;
+  isActive(unit: string): Promise<boolean>;
+}
+
+export interface SystemdResult {
+  readonly ok: boolean;
+  readonly detail?: string;
+}
+
+export interface SystemdCall {
+  readonly op: "stop" | "start" | "isActive";
+  readonly unit: string;
+}
+
+export function realSystemdController(): SystemdController {
+  return {
+    async stop(unit) {
+      return runSystemctl(["--user", "stop", unit]);
+    },
+    async start(unit) {
+      return runSystemctl(["--user", "start", unit]);
+    },
+    async isActive(unit) {
+      const result = await runSystemctl(["--user", "is-active", unit]);
+      return result.ok;
+    },
+  };
+}
+
+export interface FakeSystemdController extends SystemdController {
+  readonly calls: ReadonlyArray<SystemdCall>;
+  setActive(unit: string, active: boolean): void;
+  failOn(op: SystemdCall["op"], unit: string, detail?: string): void;
+}
+
+export function fakeSystemdController(): FakeSystemdController {
+  const calls: SystemdCall[] = [];
+  const active = new Map<string, boolean>();
+  const fails = new Map<string, { op: SystemdCall["op"]; detail?: string }>();
+  const failKey = (op: SystemdCall["op"], unit: string): string => `${op}:${unit}`;
+
+  return {
+    get calls() {
+      return calls;
+    },
+    setActive(unit, isActive) {
+      active.set(unit, isActive);
+    },
+    failOn(op, unit, detail) {
+      fails.set(failKey(op, unit), { op, ...(detail !== undefined ? { detail } : {}) });
+    },
+    async stop(unit) {
+      calls.push({ op: "stop", unit });
+      const fail = fails.get(failKey("stop", unit));
+      if (fail !== undefined) return { ok: false, ...(fail.detail !== undefined ? { detail: fail.detail } : {}) };
+      active.set(unit, false);
+      return { ok: true };
+    },
+    async start(unit) {
+      calls.push({ op: "start", unit });
+      const fail = fails.get(failKey("start", unit));
+      if (fail !== undefined) return { ok: false, ...(fail.detail !== undefined ? { detail: fail.detail } : {}) };
+      active.set(unit, true);
+      return { ok: true };
+    },
+    async isActive(unit) {
+      calls.push({ op: "isActive", unit });
+      return active.get(unit) ?? false;
+    },
+  };
+}
+
+async function runSystemctl(args: ReadonlyArray<string>): Promise<SystemdResult> {
+  const proc = Bun.spawn(["systemctl", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  if (exitCode !== 0) {
+    const tail = (stderr || stdout).trim();
+    return tail.length > 0 ? { ok: false, detail: tail } : { ok: false };
+  }
+  return { ok: true };
+}

--- a/src/cli/commands/panic.ts
+++ b/src/cli/commands/panic.ts
@@ -8,6 +8,9 @@
 
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { closeDb, openDb } from "@clawde/db/client";
+import { EventsRepo } from "@clawde/db/repositories/events";
+import { type OutputFormat, emit, emitErr } from "../output.ts";
 
 export interface PanicLockInfo {
   readonly ts: string;
@@ -145,6 +148,95 @@ export function fakeSystemdController(): FakeSystemdController {
       return active.get(unit) ?? false;
     },
   };
+}
+
+/**
+ * `clawde panic-stop` — para receiver+worker, registra event panic_stop,
+ * cria lock pra travar panic-resume sem diagnose ok. Idempotente per
+ * BLUEPRINT §6.2.
+ */
+export interface PanicStopOptions {
+  readonly dbPath: string;
+  readonly lockPath: string;
+  readonly format: OutputFormat;
+  readonly reason?: string;
+  readonly systemd?: SystemdController;
+}
+
+export interface PanicStopReport {
+  readonly ok: boolean;
+  readonly alreadyLocked: boolean;
+  readonly lock: PanicLockInfo;
+  readonly stops: ReadonlyArray<{ unit: string; ok: boolean; detail?: string }>;
+}
+
+export async function runPanicStop(options: PanicStopOptions): Promise<number> {
+  const sd = options.systemd ?? realSystemdController();
+  const alreadyLocked = panicLockExists(options.lockPath);
+  const lock = createPanicLock(options.lockPath, options.reason);
+
+  const units = ["clawde-receiver", "clawde-worker.path"];
+  const stops: Array<{ unit: string; ok: boolean; detail?: string }> = [];
+  for (const unit of units) {
+    const r = await sd.stop(unit);
+    stops.push({
+      unit,
+      ok: r.ok,
+      ...(r.detail !== undefined ? { detail: r.detail } : {}),
+    });
+  }
+
+  let dbOk = true;
+  try {
+    const db = openDb(options.dbPath);
+    try {
+      const events = new EventsRepo(db);
+      events.insert({
+        taskRunId: null,
+        sessionId: null,
+        traceId: null,
+        spanId: null,
+        kind: "panic_stop",
+        payload: {
+          lock_ts: lock.ts,
+          hostname: lock.hostname,
+          pid: lock.pid,
+          reason: lock.reason ?? null,
+          already_locked: alreadyLocked,
+          stops: stops.map((s) => ({ unit: s.unit, ok: s.ok })),
+        },
+      });
+    } finally {
+      closeDb(db);
+    }
+  } catch (err) {
+    dbOk = false;
+    emitErr(`warning: failed to persist panic_stop event: ${(err as Error).message}`);
+  }
+
+  const allStopsOk = stops.every((s) => s.ok);
+  const report: PanicStopReport = {
+    ok: allStopsOk && dbOk,
+    alreadyLocked,
+    lock,
+    stops,
+  };
+
+  emit(options.format, report, (d) => {
+    const r = d as PanicStopReport;
+    const lines = [
+      `lock:         ${r.lock.ts} (${r.alreadyLocked ? "preexisting" : "new"})`,
+      `host/pid:     ${r.lock.hostname}/${r.lock.pid}`,
+      ...(r.lock.reason !== undefined ? [`reason:       ${r.lock.reason}`] : []),
+      ...r.stops.map(
+        (s) => `[${s.ok ? "OK " : "FAIL"}] systemctl stop ${s.unit}${s.detail !== undefined ? `: ${s.detail}` : ""}`,
+      ),
+      `overall: ${r.ok ? "OK" : "DEGRADED"}`,
+    ];
+    return lines.join("\n");
+  });
+
+  return 0;
 }
 
 async function runSystemctl(args: ReadonlyArray<string>): Promise<SystemdResult> {

--- a/src/cli/commands/panic.ts
+++ b/src/cli/commands/panic.ts
@@ -1,0 +1,70 @@
+/**
+ * `clawde panic-stop` / `panic-resume` — gate operacional pra travar/destravar
+ * o daemon. Idempotente. Lock file persistente em `<clawde.home>/panic.lock`
+ * sinaliza estado pro `panic-resume` e pra outros operadores.
+ *
+ * Sub-fase P3.2 (T-104, T-105). Spec em EXECUTION_BACKLOG.md §P3.2.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface PanicLockInfo {
+  readonly ts: string;
+  readonly hostname: string;
+  readonly pid: number;
+  readonly reason?: string;
+}
+
+/**
+ * Cria lock file em `lockPath`. Idempotente: se já existir, retorna o info
+ * preexistente sem sobrescrever (preserva quem trancou primeiro).
+ *
+ * Não cria diretórios pais? Cria — falha menos friendly se `<clawde.home>`
+ * não existir.
+ */
+export function createPanicLock(lockPath: string, reason?: string): PanicLockInfo {
+  if (existsSync(lockPath)) {
+    return readPanicLock(lockPath);
+  }
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const info: PanicLockInfo = {
+    ts: new Date().toISOString(),
+    hostname: hostnameSafe(),
+    pid: process.pid,
+    ...(reason !== undefined ? { reason } : {}),
+  };
+  writeFileSync(lockPath, JSON.stringify(info, null, 2), "utf-8");
+  return info;
+}
+
+export function panicLockExists(lockPath: string): boolean {
+  return existsSync(lockPath);
+}
+
+/**
+ * Lê info do lock. Throw se ausente — caller deve checar `panicLockExists`
+ * primeiro se quiser tolerância.
+ */
+export function readPanicLock(lockPath: string): PanicLockInfo {
+  const raw = readFileSync(lockPath, "utf-8");
+  return JSON.parse(raw) as PanicLockInfo;
+}
+
+/**
+ * Remove lock file. Idempotente: no-op se já ausente.
+ */
+export function removePanicLock(lockPath: string): void {
+  if (!existsSync(lockPath)) return;
+  rmSync(lockPath, { force: true });
+}
+
+function hostnameSafe(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const os = require("node:os") as typeof import("node:os");
+    return os.hostname();
+  } catch {
+    return "unknown";
+  }
+}

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -1,0 +1,156 @@
+/**
+ * `clawde sessions list|show <id>` — visibility sobre estado das sessões
+ * persistentes do SDK. Sub-fase P3.2 (T-107, T-108).
+ */
+
+import type { Session, SessionState } from "@clawde/domain/session";
+import { closeDb, openDb } from "@clawde/db/client";
+import { type OutputFormat, emit, emitErr } from "../output.ts";
+
+export interface SessionsListOptions {
+  readonly dbPath: string;
+  readonly format: OutputFormat;
+  readonly limit?: number;
+}
+
+export interface SessionsShowOptions {
+  readonly dbPath: string;
+  readonly format: OutputFormat;
+  readonly sessionId: string;
+  readonly nowMs?: () => number;
+}
+
+interface SessionRow {
+  readonly session_id: string;
+  readonly agent: string;
+  readonly state: SessionState;
+  readonly last_used_at: string | null;
+  readonly msg_count: number;
+  readonly token_estimate: number;
+  readonly created_at: string;
+}
+
+function rowToSession(r: SessionRow): Session {
+  return {
+    sessionId: r.session_id,
+    agent: r.agent,
+    state: r.state,
+    lastUsedAt: r.last_used_at,
+    msgCount: r.msg_count,
+    tokenEstimate: r.token_estimate,
+    createdAt: r.created_at,
+  };
+}
+
+export function runSessionsList(options: SessionsListOptions): number {
+  const limit = options.limit ?? 100;
+  try {
+    const db = openDb(options.dbPath);
+    try {
+      const rows = db
+        .query<SessionRow, [number]>(
+          `SELECT session_id, agent, state, last_used_at, msg_count, token_estimate, created_at
+           FROM sessions
+           ORDER BY last_used_at DESC NULLS LAST, created_at DESC
+           LIMIT ?`,
+        )
+        .all(limit);
+      const sessions = rows.map(rowToSession);
+      emit(options.format, sessions, (d) => {
+        const list = d as ReadonlyArray<Session>;
+        if (list.length === 0) return "(no sessions)";
+        const header =
+          "session_id                            agent             state             last_used_at         msgs   tokens";
+        const lines = list.map((s) => {
+          const id = s.sessionId.padEnd(36);
+          const agent = (s.agent ?? "").padEnd(17);
+          const state = s.state.padEnd(17);
+          const last = (s.lastUsedAt ?? "—").padEnd(20);
+          const msgs = String(s.msgCount).padStart(5);
+          const toks = String(s.tokenEstimate).padStart(8);
+          return `${id} ${agent} ${state} ${last} ${msgs} ${toks}`;
+        });
+        return [header, ...lines].join("\n");
+      });
+      return 0;
+    } finally {
+      closeDb(db);
+    }
+  } catch (err) {
+    emitErr(`error: ${(err as Error).message}`);
+    return 2;
+  }
+}
+
+export interface SessionShowReport {
+  readonly session: Session;
+  readonly eventsCount: number;
+  readonly warnings: ReadonlyArray<string>;
+}
+
+export function runSessionsShow(options: SessionsShowOptions): number {
+  try {
+    const db = openDb(options.dbPath);
+    try {
+      const row = db
+        .query<SessionRow, [string]>(
+          `SELECT session_id, agent, state, last_used_at, msg_count, token_estimate, created_at
+           FROM sessions WHERE session_id = ?`,
+        )
+        .get(options.sessionId);
+      if (row === null) {
+        emitErr(`error: session ${options.sessionId} not found`);
+        return 1;
+      }
+      const session = rowToSession(row);
+      const eventsRow = db
+        .query<{ n: number }, [string]>(
+          `SELECT COUNT(*) AS n FROM events WHERE session_id = ?`,
+        )
+        .get(options.sessionId);
+      const eventsCount = eventsRow?.n ?? 0;
+      const warnings: string[] = [];
+      if (
+        session.state === "compact_pending" &&
+        session.lastUsedAt !== null &&
+        ageDays(session.lastUsedAt, options.nowMs?.() ?? Date.now()) > 7
+      ) {
+        warnings.push(
+          `state=compact_pending há mais de 7 dias (last_used_at=${session.lastUsedAt})`,
+        );
+      }
+
+      const report: SessionShowReport = { session, eventsCount, warnings };
+      emit(options.format, report, (d) => {
+        const r = d as SessionShowReport;
+        const lines = [
+          `session_id:     ${r.session.sessionId}`,
+          `agent:          ${r.session.agent}`,
+          `state:          ${r.session.state}`,
+          `created_at:     ${r.session.createdAt}`,
+          `last_used_at:   ${r.session.lastUsedAt ?? "(never)"}`,
+          `msg_count:      ${r.session.msgCount}`,
+          `token_estimate: ${r.session.tokenEstimate}`,
+          `events_count:   ${r.eventsCount}`,
+        ];
+        if (r.warnings.length > 0) {
+          lines.push("");
+          for (const w of r.warnings) lines.push(`WARNING: ${w}`);
+        }
+        return lines.join("\n");
+      });
+      return 0;
+    } finally {
+      closeDb(db);
+    }
+  } catch (err) {
+    emitErr(`error: ${(err as Error).message}`);
+    return 2;
+  }
+}
+
+function ageDays(isoTimestamp: string, nowMs: number): number {
+  const then = Date.parse(isoTimestamp.replace(" ", "T") + (isoTimestamp.includes("Z") ? "" : "Z"));
+  if (Number.isNaN(then)) return 0;
+  return (nowMs - then) / (24 * 60 * 60 * 1000);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -12,14 +12,18 @@
 import type { EventKind } from "@clawde/domain/event";
 import { runAgents } from "./commands/agents.ts";
 import { runAuth } from "./commands/auth.ts";
+import { runConfigShow, runConfigValidate } from "./commands/config.ts";
 import { runDashboard } from "./commands/dashboard.ts";
+import { DIAGNOSE_SUBJECTS, type DiagnoseSubject, runDiagnose } from "./commands/diagnose.ts";
 import { runLogs } from "./commands/logs.ts";
 import { runMemory } from "./commands/memory.ts";
 import { runMigrate } from "./commands/migrate.ts";
+import { runPanicResume, runPanicStop } from "./commands/panic.ts";
 import { runQueue } from "./commands/queue.ts";
 import { runQuota } from "./commands/quota.ts";
 import { runReplica } from "./commands/replica.ts";
 import { runReview } from "./commands/review.ts";
+import { runSessionsList, runSessionsShow } from "./commands/sessions.ts";
 import { runSmokeTest } from "./commands/smoke-test.ts";
 import { runTrace } from "./commands/trace.ts";
 import { type OutputFormat, emit, emitErr } from "./output.ts";
@@ -81,6 +85,10 @@ function getOutputFormat(parsed: ParsedArgs): OutputFormat {
   return v === "json" ? "json" : "text";
 }
 
+function defaultLockPath(): string {
+  return `${process.env.HOME ?? ""}/.clawde/panic.lock`;
+}
+
 function getDbPath(parsed: ParsedArgs): string {
   return (
     getFlag(parsed, "db") ?? process.env.CLAWDE_DB ?? `${process.env.HOME ?? ""}/.clawde/state.db`
@@ -101,6 +109,11 @@ Commands:
   replica <status|verify>  Saúde do Litestream replica
   review history <run-id>  Histórico do pipeline de review (Fase 9)
   agents list             Lista AGENT.md carregados
+  diagnose <db|quota|oauth|sandbox|agents|all>  Health check por subsistema
+  panic-stop [--reason <s>]  Trava o daemon (lock + stop receiver/worker.path)
+  panic-resume           Destrava após panic-stop (requer diagnose all=ok)
+  sessions <list|show <id>>  Inspeciona sessões persistentes do SDK
+  config <show|validate <path>>  Dump/valida config TOML resolvida
   version                Mostra semver
   help                   Esta mensagem
 
@@ -146,6 +159,96 @@ export async function runMain(argv: ReadonlyArray<string>): Promise<number> {
       Object.assign(opts, { includeSdkPing: true });
     }
     return await runSmokeTest(opts);
+  }
+
+  if (parsed.command === "diagnose") {
+    const subject = (parsed.positional[0] ?? "all") as DiagnoseSubject;
+    if (!DIAGNOSE_SUBJECTS.includes(subject)) {
+      emitErr(`unknown diagnose subject: ${subject} (use ${DIAGNOSE_SUBJECTS.join("|")})`);
+      return 1;
+    }
+    const diagOpts: Parameters<typeof runDiagnose>[0] = {
+      dbPath: getDbPath(parsed),
+      format: getOutputFormat(parsed),
+      subject,
+    };
+    const aRoot = getFlag(parsed, "agents-root");
+    if (aRoot !== undefined && aRoot.length > 0) Object.assign(diagOpts, { agentsRoot: aRoot });
+    return await runDiagnose(diagOpts);
+  }
+
+  if (parsed.command === "panic-stop") {
+    const lockPath = getFlag(parsed, "lock-path") ?? defaultLockPath();
+    const opts: Parameters<typeof runPanicStop>[0] = {
+      dbPath: getDbPath(parsed),
+      lockPath,
+      format: getOutputFormat(parsed),
+    };
+    const reason = getFlag(parsed, "reason");
+    if (reason !== undefined && reason.length > 0) Object.assign(opts, { reason });
+    return await runPanicStop(opts);
+  }
+
+  if (parsed.command === "panic-resume") {
+    const lockPath = getFlag(parsed, "lock-path") ?? defaultLockPath();
+    const opts: Parameters<typeof runPanicResume>[0] = {
+      dbPath: getDbPath(parsed),
+      lockPath,
+      format: getOutputFormat(parsed),
+    };
+    const aRoot = getFlag(parsed, "agents-root");
+    if (aRoot !== undefined && aRoot.length > 0) Object.assign(opts, { agentsRoot: aRoot });
+    return await runPanicResume(opts);
+  }
+
+  if (parsed.command === "sessions") {
+    const action = parsed.positional[0] ?? "list";
+    if (action === "list") {
+      const limStr = getFlag(parsed, "limit");
+      const opts: Parameters<typeof runSessionsList>[0] = {
+        dbPath: getDbPath(parsed),
+        format: getOutputFormat(parsed),
+      };
+      if (limStr !== undefined) {
+        const lim = Number.parseInt(limStr, 10);
+        if (Number.isFinite(lim) && lim > 0) Object.assign(opts, { limit: lim });
+      }
+      return runSessionsList(opts);
+    }
+    if (action === "show") {
+      const id = parsed.positional[1];
+      if (id === undefined || id.length === 0) {
+        emitErr("error: sessions show requires <session-id>");
+        return 1;
+      }
+      return runSessionsShow({
+        dbPath: getDbPath(parsed),
+        format: getOutputFormat(parsed),
+        sessionId: id,
+      });
+    }
+    emitErr(`unknown sessions action: ${action} (use list|show <id>)`);
+    return 1;
+  }
+
+  if (parsed.command === "config") {
+    const action = parsed.positional[0] ?? "show";
+    if (action === "show") {
+      const path = getFlag(parsed, "path");
+      const opts: Parameters<typeof runConfigShow>[0] = { format: getOutputFormat(parsed) };
+      if (path !== undefined && path.length > 0) Object.assign(opts, { path });
+      return runConfigShow(opts);
+    }
+    if (action === "validate") {
+      const path = parsed.positional[1] ?? getFlag(parsed, "path");
+      if (path === undefined || path.length === 0) {
+        emitErr("error: config validate requires <path>");
+        return 1;
+      }
+      return runConfigValidate({ format: getOutputFormat(parsed), path });
+    }
+    emitErr(`unknown config action: ${action} (use show|validate <path>)`);
+    return 1;
   }
 
   if (parsed.command === "migrate") {

--- a/tests/integration/config-cmd.test.ts
+++ b/tests/integration/config-cmd.test.ts
@@ -128,4 +128,77 @@ describe("cli/commands/config show+validate", () => {
     expect(exit).toBe(1);
     expect(stderr).toContain("not found");
   });
+
+  test("show classifica origem por campo: toml vence default, env vence toml", async () => {
+    // TOML define apenas clawde.home. quota.plan vai vir de env;
+    // log_level fica default (não setado).
+    writeFileSync(configPath, `[clawde]\nhome = "${dir}"\n`, "utf-8");
+    const prevPlan = process.env.CLAWDE_QUOTA_PLAN;
+    process.env.CLAWDE_QUOTA_PLAN = "max5x";
+    try {
+      const { exit, stdout } = await captureOutput(() =>
+        runConfigShow({ format: "json", path: configPath }),
+      );
+      expect(exit).toBe(0);
+      const report = JSON.parse(stdout) as ConfigShowReport;
+      expect(report.sources["clawde.home"]).toBe("toml");
+      expect(report.sources["quota.plan"]).toBe("env");
+      expect(report.sources["clawde.log_level"]).toBe("default");
+    } finally {
+      if (prevPlan !== undefined) {
+        process.env.CLAWDE_QUOTA_PLAN = prevPlan;
+      } else {
+        delete process.env.CLAWDE_QUOTA_PLAN;
+      }
+    }
+  });
+
+  test("show: env vence toml para o mesmo campo", async () => {
+    writeFileSync(
+      configPath,
+      `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`,
+      "utf-8",
+    );
+    const prevLevel = process.env.CLAWDE_LOG_LEVEL;
+    process.env.CLAWDE_LOG_LEVEL = "DEBUG";
+    try {
+      const { exit, stdout } = await captureOutput(() =>
+        runConfigShow({ format: "json", path: configPath }),
+      );
+      expect(exit).toBe(0);
+      const report = JSON.parse(stdout) as ConfigShowReport;
+      expect(report.sources["clawde.log_level"]).toBe("env");
+      expect(report.sources["clawde.home"]).toBe("toml");
+    } finally {
+      if (prevLevel !== undefined) {
+        process.env.CLAWDE_LOG_LEVEL = prevLevel;
+      } else {
+        delete process.env.CLAWDE_LOG_LEVEL;
+      }
+    }
+  });
+
+  test("show: campo no TOML mas com env var vazia continua toml (não env)", async () => {
+    writeFileSync(
+      configPath,
+      `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`,
+      "utf-8",
+    );
+    const prevLevel = process.env.CLAWDE_LOG_LEVEL;
+    process.env.CLAWDE_LOG_LEVEL = "";
+    try {
+      const { stdout } = await captureOutput(() =>
+        runConfigShow({ format: "json", path: configPath }),
+      );
+      const report = JSON.parse(stdout) as ConfigShowReport;
+      // Per load.ts, env var vazia é ignorada — log_level deve refletir TOML.
+      expect(report.sources["clawde.log_level"]).toBe("toml");
+    } finally {
+      if (prevLevel !== undefined) {
+        process.env.CLAWDE_LOG_LEVEL = prevLevel;
+      } else {
+        delete process.env.CLAWDE_LOG_LEVEL;
+      }
+    }
+  });
 });

--- a/tests/integration/config-cmd.test.ts
+++ b/tests/integration/config-cmd.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type ConfigShowReport,
+  type ConfigValidateReport,
+  runConfigShow,
+  runConfigValidate,
+} from "@clawde/cli/commands/config";
+
+function captureOutput(fn: () => Promise<number> | number): Promise<{
+  exit: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+  process.stdout.write = ((c: unknown): boolean => {
+    stdout += String(c);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((c: unknown): boolean => {
+    stderr += String(c);
+    return true;
+  }) as typeof process.stderr.write;
+  return Promise.resolve(fn())
+    .then((exit) => ({ exit, stdout, stderr }))
+    .finally(() => {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    });
+}
+
+describe("cli/commands/config show+validate", () => {
+  let dir: string;
+  let configPath: string;
+  let prevConfigEnv: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "clawde-config-cmd-"));
+    configPath = join(dir, "clawde.toml");
+    prevConfigEnv = process.env.CLAWDE_CONFIG;
+  });
+
+  afterEach(() => {
+    if (prevConfigEnv !== undefined) {
+      process.env.CLAWDE_CONFIG = prevConfigEnv;
+    } else {
+      delete process.env.CLAWDE_CONFIG;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("show com config válido retorna 0 + report estruturado", async () => {
+    writeFileSync(
+      configPath,
+      `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`,
+      "utf-8",
+    );
+    const { exit, stdout } = await captureOutput(() =>
+      runConfigShow({ format: "json", path: configPath }),
+    );
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as ConfigShowReport;
+    expect(report.resolvedPath).toBe(configPath);
+    expect(report.tomlExists).toBe(true);
+    expect(report.config).toBeDefined();
+  });
+
+  test("show retorna exit 1 quando TOML é inválido (zod)", async () => {
+    // home faltando obrigatório seria zod fail; deixa apenas log_level com valor inválido
+    writeFileSync(configPath, '[clawde]\nlog_level = "BOGUS"\n', "utf-8");
+    const { exit, stderr } = await captureOutput(() =>
+      runConfigShow({ format: "text", path: configPath }),
+    );
+    expect(exit).toBe(1);
+    expect(stderr).toContain("invalid config");
+  });
+
+  test("show com path inexistente cai em defaults (tomlExists=false)", async () => {
+    const ghostPath = join(dir, "ghost.toml");
+    const { exit, stdout } = await captureOutput(() =>
+      runConfigShow({ format: "json", path: ghostPath }),
+    );
+    // Defaults zod deveriam validar (campos com defaults).
+    // Se algum campo for required-without-default, o exit pode ser 1.
+    expect([0, 1]).toContain(exit);
+    if (exit === 0) {
+      const report = JSON.parse(stdout) as ConfigShowReport;
+      expect(report.tomlExists).toBe(false);
+    }
+  });
+
+  test("validate retorna 0 em TOML válido", async () => {
+    writeFileSync(
+      configPath,
+      `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`,
+      "utf-8",
+    );
+    const { exit, stdout } = await captureOutput(() =>
+      runConfigValidate({ format: "json", path: configPath }),
+    );
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as ConfigValidateReport;
+    expect(report.ok).toBe(true);
+    expect(report.issues).toHaveLength(0);
+  });
+
+  test("validate retorna 1 + lista issues em TOML inválido", async () => {
+    writeFileSync(configPath, '[clawde]\nlog_level = "BOGUS"\n', "utf-8");
+    const { exit, stdout } = await captureOutput(() =>
+      runConfigValidate({ format: "json", path: configPath }),
+    );
+    expect(exit).toBe(1);
+    const report = JSON.parse(stdout) as ConfigValidateReport;
+    expect(report.ok).toBe(false);
+    expect(report.issues.length).toBeGreaterThan(0);
+  });
+
+  test("validate retorna 1 quando arquivo não existe", async () => {
+    const ghost = join(dir, "ghost.toml");
+    const { exit, stderr } = await captureOutput(() =>
+      runConfigValidate({ format: "text", path: ghost }),
+    );
+    expect(exit).toBe(1);
+    expect(stderr).toContain("not found");
+  });
+});

--- a/tests/integration/diagnose.test.ts
+++ b/tests/integration/diagnose.test.ts
@@ -137,8 +137,9 @@ describe("cli/commands/diagnose", () => {
         runDiagnose({ dbPath, format: "json", subject: "oauth" }),
       );
       const report = JSON.parse(stdout) as DiagnoseReport;
+      const status = report.checks[0]?.status ?? "missing";
       // Aceita warn (token ausente) ou ok (token presente em CI).
-      expect(["ok", "warn"]).toContain(report.checks[0]?.status);
+      expect(["ok", "warn"]).toContain(status);
       expect([0, 1]).toContain(exit);
     } finally {
       if (prevToken !== undefined) process.env.HOME = prevToken;

--- a/tests/integration/diagnose.test.ts
+++ b/tests/integration/diagnose.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type DiagnoseReport,
+  runDiagnose,
+} from "@clawde/cli/commands/diagnose";
+import { closeDb, openDb } from "@clawde/db/client";
+import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
+
+function captureOutput(fn: () => Promise<number> | number): Promise<{
+  exit: number;
+  stdout: string;
+}> {
+  const orig = process.stdout.write.bind(process.stdout);
+  let stdout = "";
+  process.stdout.write = ((c: unknown): boolean => {
+    stdout += String(c);
+    return true;
+  }) as typeof process.stdout.write;
+  return Promise.resolve(fn())
+    .then((exit) => ({ exit, stdout }))
+    .finally(() => {
+      process.stdout.write = orig;
+    });
+}
+
+describe("cli/commands/diagnose", () => {
+  let dir: string;
+  let dbPath: string;
+  let agentsRoot: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "clawde-diagnose-"));
+    dbPath = join(dir, "state.db");
+    agentsRoot = join(dir, "agents");
+    const db = openDb(dbPath);
+    applyPending(db, defaultMigrationsDir());
+    closeDb(db);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("subject=db retorna ok em DB válido", async () => {
+    const { exit, stdout } = await captureOutput(() =>
+      runDiagnose({ dbPath, format: "json", subject: "db" }),
+    );
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as DiagnoseReport;
+    expect(report.subject).toBe("db");
+    expect(report.status).toBe("ok");
+    expect(report.checks[0]?.name).toBe("db.integrity");
+  });
+
+  test("subject=db retorna error em DB inexistente", async () => {
+    const { exit, stdout } = await captureOutput(() =>
+      runDiagnose({ dbPath: join(dir, "nope.db"), format: "json", subject: "db" }),
+    );
+    // openDb cria DB vazio em vez de falhar; integrity_check passa em DB vazio.
+    // Aceita ok ou error — só queremos garantir que o handler não crasha.
+    expect([0, 2]).toContain(exit);
+    const report = JSON.parse(stdout) as DiagnoseReport;
+    expect(report.subject).toBe("db");
+  });
+
+  test("subject=quota retorna ok em DB sem consumo", async () => {
+    const { exit, stdout } = await captureOutput(() =>
+      runDiagnose({ dbPath, format: "json", subject: "quota" }),
+    );
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as DiagnoseReport;
+    expect(report.checks[0]?.name).toBe("quota.window");
+    expect(report.checks[0]?.status).toBe("ok");
+  });
+
+  test("subject=agents retorna warn em root inexistente", async () => {
+    const { exit, stdout } = await captureOutput(() =>
+      runDiagnose({ dbPath, format: "json", subject: "agents", agentsRoot }),
+    );
+    expect(exit).toBe(1);
+    const report = JSON.parse(stdout) as DiagnoseReport;
+    expect(report.checks[0]?.status).toBe("warn");
+    expect(report.checks[0]?.detail).toContain("not found");
+  });
+
+  test("subject=agents lista agentes carregados em root válido", async () => {
+    const agentDir = join(agentsRoot, "implementer");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, "AGENT.md"),
+      [
+        "---",
+        "name: implementer",
+        'role: "Implementa"',
+        "model: sonnet",
+        "allowedTools: [Read]",
+        "disallowedTools: []",
+        "maxTurns: 5",
+        "sandboxLevel: 1",
+        "requiresWorkspace: false",
+        "---",
+        "",
+        "# System Prompt",
+        "stub.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(join(agentDir, "sandbox.toml"), 'level = 1\nnetwork = "none"\n', "utf-8");
+
+    const { exit, stdout } = await captureOutput(() =>
+      runDiagnose({ dbPath, format: "text", subject: "agents", agentsRoot }),
+    );
+    expect(exit).toBe(0);
+    expect(stdout).toContain("[OK  ] agents.load");
+    expect(stdout).toContain("implementer=L1");
+  });
+
+  test("subject=sandbox sem agents level>=2 retorna ok", async () => {
+    const { exit, stdout } = await captureOutput(() =>
+      runDiagnose({ dbPath, format: "json", subject: "sandbox", agentsRoot }),
+    );
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as DiagnoseReport;
+    expect(report.checks[0]?.status).toBe("ok");
+  });
+
+  test("subject=oauth retorna warn quando token ausente", async () => {
+    const prevToken = process.env.HOME;
+    const fakeHome = mkdtempSync(join(tmpdir(), "clawde-diag-home-"));
+    process.env.HOME = fakeHome;
+    try {
+      const { exit, stdout } = await captureOutput(() =>
+        runDiagnose({ dbPath, format: "json", subject: "oauth" }),
+      );
+      const report = JSON.parse(stdout) as DiagnoseReport;
+      // Aceita warn (token ausente) ou ok (token presente em CI).
+      expect(["ok", "warn"]).toContain(report.checks[0]?.status);
+      expect([0, 1]).toContain(exit);
+    } finally {
+      if (prevToken !== undefined) process.env.HOME = prevToken;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("subject=all agrega múltiplos checks; status = pior dos sub-checks", async () => {
+    const { exit, stdout } = await captureOutput(() =>
+      runDiagnose({ dbPath, format: "json", subject: "all", agentsRoot }),
+    );
+    const report = JSON.parse(stdout) as DiagnoseReport;
+    expect(report.subject).toBe("all");
+    // 5 sub-checks: db, quota, oauth, sandbox, agents
+    expect(report.checks).toHaveLength(5);
+    // agents=warn (root inexistente) → overall warn no mínimo
+    expect(["warn", "error"]).toContain(report.status);
+    expect([1, 2]).toContain(exit);
+  });
+});

--- a/tests/integration/panic-resume.test.ts
+++ b/tests/integration/panic-resume.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type PanicResumeReport,
+  createPanicLock,
+  fakeSystemdController,
+  runPanicResume,
+} from "@clawde/cli/commands/panic";
+
+function captureOutput(fn: () => Promise<number> | number): Promise<{
+  exit: number;
+  stdout: string;
+}> {
+  const orig = process.stdout.write.bind(process.stdout);
+  let stdout = "";
+  process.stdout.write = ((c: unknown): boolean => {
+    stdout += String(c);
+    return true;
+  }) as typeof process.stdout.write;
+  return Promise.resolve(fn())
+    .then((exit) => ({ exit, stdout }))
+    .finally(() => {
+      process.stdout.write = orig;
+    });
+}
+
+describe("cli/commands/panic runPanicResume", () => {
+  let dir: string;
+  let dbPath: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "clawde-panic-resume-"));
+    dbPath = join(dir, "state.db");
+    lockPath = join(dir, "panic.lock");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("recusa resume quando diagnose retorna warn", async () => {
+    createPanicLock(lockPath);
+    const sd = fakeSystemdController();
+    const { exit, stdout } = await captureOutput(() =>
+      runPanicResume({
+        dbPath,
+        lockPath,
+        format: "json",
+        systemd: sd,
+        diagnose: async () => ({
+          subject: "all",
+          status: "warn",
+          checks: [{ name: "agents.load", status: "warn", detail: "0 agents defined" }],
+        }),
+      }),
+    );
+    expect(exit).toBe(1);
+    const report = JSON.parse(stdout) as PanicResumeReport;
+    expect(report.ok).toBe(false);
+    expect(report.lockRemoved).toBe(false);
+    expect(report.refusedReason).toContain("status=warn");
+    expect(existsSync(lockPath)).toBe(true);
+    expect(sd.calls).toHaveLength(0);
+  });
+
+  test("recusa resume quando diagnose retorna error", async () => {
+    createPanicLock(lockPath);
+    const sd = fakeSystemdController();
+    const { exit } = await captureOutput(() =>
+      runPanicResume({
+        dbPath,
+        lockPath,
+        format: "json",
+        systemd: sd,
+        diagnose: async () => ({
+          subject: "all",
+          status: "error",
+          checks: [{ name: "db.integrity", status: "error", detail: "corruption" }],
+        }),
+      }),
+    );
+    expect(exit).toBe(1);
+    expect(existsSync(lockPath)).toBe(true);
+  });
+
+  test("happy path: diagnose ok → remove lock + start receiver → exit 0", async () => {
+    createPanicLock(lockPath, "previous incident");
+    const sd = fakeSystemdController();
+    const { exit, stdout } = await captureOutput(() =>
+      runPanicResume({
+        dbPath,
+        lockPath,
+        format: "json",
+        systemd: sd,
+        diagnose: async () => ({
+          subject: "all",
+          status: "ok",
+          checks: [{ name: "db.integrity", status: "ok", detail: "ok" }],
+        }),
+      }),
+    );
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as PanicResumeReport;
+    expect(report.ok).toBe(true);
+    expect(report.lockRemoved).toBe(true);
+    expect(report.start?.unit).toBe("clawde-receiver");
+    expect(report.start?.ok).toBe(true);
+    expect(existsSync(lockPath)).toBe(false);
+    expect(sd.calls).toEqual([{ op: "start", unit: "clawde-receiver" }]);
+  });
+
+  test("retorna exit 2 quando systemctl start falha", async () => {
+    createPanicLock(lockPath);
+    const sd = fakeSystemdController();
+    sd.failOn("start", "clawde-receiver", "Failed to start unit");
+    const { exit, stdout } = await captureOutput(() =>
+      runPanicResume({
+        dbPath,
+        lockPath,
+        format: "text",
+        systemd: sd,
+        diagnose: async () => ({
+          subject: "all",
+          status: "ok",
+          checks: [],
+        }),
+      }),
+    );
+    expect(exit).toBe(2);
+    expect(stdout).toContain("[FAIL] systemctl start clawde-receiver");
+    expect(stdout).toContain("Failed to start unit");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});

--- a/tests/integration/panic-stop.test.ts
+++ b/tests/integration/panic-stop.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type PanicStopReport,
+  fakeSystemdController,
+  runPanicStop,
+} from "@clawde/cli/commands/panic";
+import { closeDb, openDb } from "@clawde/db/client";
+import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
+import { EventsRepo } from "@clawde/db/repositories/events";
+
+function captureOutput(fn: () => Promise<number> | number): Promise<{
+  exit: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+  process.stdout.write = ((c: unknown): boolean => {
+    stdout += String(c);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((c: unknown): boolean => {
+    stderr += String(c);
+    return true;
+  }) as typeof process.stderr.write;
+  return Promise.resolve(fn())
+    .then((exit) => ({ exit, stdout, stderr }))
+    .finally(() => {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    });
+}
+
+describe("cli/commands/panic runPanicStop", () => {
+  let dir: string;
+  let dbPath: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "clawde-panic-stop-"));
+    dbPath = join(dir, "state.db");
+    lockPath = join(dir, "panic.lock");
+    const db = openDb(dbPath);
+    applyPending(db, defaultMigrationsDir());
+    closeDb(db);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("happy path: cria lock, para units, persiste event panic_stop", async () => {
+    const sd = fakeSystemdController();
+    sd.setActive("clawde-receiver", true);
+    sd.setActive("clawde-worker.path", true);
+
+    const { exit, stdout } = await captureOutput(() =>
+      runPanicStop({ dbPath, lockPath, format: "json", reason: "incident #42", systemd: sd }),
+    );
+
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as PanicStopReport;
+    expect(report.ok).toBe(true);
+    expect(report.alreadyLocked).toBe(false);
+    expect(report.lock.reason).toBe("incident #42");
+    expect(report.stops.map((s) => s.unit)).toEqual(["clawde-receiver", "clawde-worker.path"]);
+    expect(report.stops.every((s) => s.ok)).toBe(true);
+    expect(existsSync(lockPath)).toBe(true);
+    expect(sd.calls.map((c) => `${c.op}:${c.unit}`)).toEqual([
+      "stop:clawde-receiver",
+      "stop:clawde-worker.path",
+    ]);
+
+    const db = openDb(dbPath);
+    try {
+      const rows = db
+        .query<{ kind: string; payload: string }, []>(
+          "SELECT kind, payload FROM events WHERE kind='panic_stop'",
+        )
+        .all();
+      expect(rows).toHaveLength(1);
+      const payload = JSON.parse(rows[0]!.payload) as Record<string, unknown>;
+      expect(payload.reason).toBe("incident #42");
+      expect(payload.already_locked).toBe(false);
+    } finally {
+      closeDb(db);
+    }
+  });
+
+  test("idempotente: segunda chamada preserva lock original e ainda registra event", async () => {
+    const sd = fakeSystemdController();
+    await runPanicStop({ dbPath, lockPath, format: "json", reason: "first", systemd: sd });
+
+    const sd2 = fakeSystemdController();
+    const { exit, stdout } = await captureOutput(() =>
+      runPanicStop({ dbPath, lockPath, format: "json", reason: "second", systemd: sd2 }),
+    );
+
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as PanicStopReport;
+    expect(report.alreadyLocked).toBe(true);
+    expect(report.lock.reason).toBe("first");
+
+    const db = openDb(dbPath);
+    try {
+      const events = new EventsRepo(db);
+      const all = events.querySince("1970-01-01T00:00:00Z", 100).filter((e) => e.kind === "panic_stop");
+      expect(all).toHaveLength(2);
+    } finally {
+      closeDb(db);
+    }
+  });
+
+  test("falha em stop produz overall DEGRADED mas exit 0 (idempotente)", async () => {
+    const sd = fakeSystemdController();
+    sd.failOn("stop", "clawde-receiver", "Failed: unit not loaded.");
+
+    const { exit, stdout } = await captureOutput(() =>
+      runPanicStop({ dbPath, lockPath, format: "text", systemd: sd }),
+    );
+
+    expect(exit).toBe(0);
+    expect(stdout).toContain("[FAIL] systemctl stop clawde-receiver");
+    expect(stdout).toContain("Failed: unit not loaded.");
+    expect(stdout).toContain("overall: DEGRADED");
+  });
+});

--- a/tests/integration/sessions-cmd.test.ts
+++ b/tests/integration/sessions-cmd.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type SessionShowReport,
+  runSessionsList,
+  runSessionsShow,
+} from "@clawde/cli/commands/sessions";
+import { type ClawdeDatabase, closeDb, openDb } from "@clawde/db/client";
+import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
+import { EventsRepo } from "@clawde/db/repositories/events";
+import { SessionsRepo } from "@clawde/db/repositories/sessions";
+
+function captureOutput(fn: () => Promise<number> | number): Promise<{
+  exit: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+  process.stdout.write = ((c: unknown): boolean => {
+    stdout += String(c);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((c: unknown): boolean => {
+    stderr += String(c);
+    return true;
+  }) as typeof process.stderr.write;
+  return Promise.resolve(fn())
+    .then((exit) => ({ exit, stdout, stderr }))
+    .finally(() => {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    });
+}
+
+describe("cli/commands/sessions list+show", () => {
+  let dir: string;
+  let dbPath: string;
+  let db: ClawdeDatabase;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "clawde-sessions-cmd-"));
+    dbPath = join(dir, "state.db");
+    db = openDb(dbPath);
+    applyPending(db, defaultMigrationsDir());
+  });
+
+  afterEach(() => {
+    closeDb(db);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("list em DB sem sessões retorna stdout '(no sessions)'", async () => {
+    const { exit, stdout } = await captureOutput(() =>
+      runSessionsList({ dbPath, format: "text" }),
+    );
+    expect(exit).toBe(0);
+    expect(stdout).toContain("(no sessions)");
+  });
+
+  test("list em JSON retorna array de sessions ordenadas", async () => {
+    const repo = new SessionsRepo(db);
+    repo.upsert({ sessionId: "sess-a", agent: "implementer" });
+    repo.upsert({ sessionId: "sess-b", agent: "verifier" });
+    repo.markUsed("sess-a", 3, 120);
+
+    const { exit, stdout } = await captureOutput(() =>
+      runSessionsList({ dbPath, format: "json" }),
+    );
+    expect(exit).toBe(0);
+    const list = JSON.parse(stdout) as Array<{ sessionId: string; msgCount: number }>;
+    expect(list).toHaveLength(2);
+    // sess-a tem last_used_at; sess-b nunca foi marcada — sess-a deve vir primeiro
+    expect(list[0]?.sessionId).toBe("sess-a");
+    expect(list[0]?.msgCount).toBe(3);
+  });
+
+  test("show retorna detalhes + eventsCount=0 quando sem events", async () => {
+    const repo = new SessionsRepo(db);
+    repo.upsert({ sessionId: "sess-c", agent: "implementer" });
+
+    const { exit, stdout } = await captureOutput(() =>
+      runSessionsShow({ dbPath, format: "json", sessionId: "sess-c" }),
+    );
+    expect(exit).toBe(0);
+    const report = JSON.parse(stdout) as SessionShowReport;
+    expect(report.session.sessionId).toBe("sess-c");
+    expect(report.session.agent).toBe("implementer");
+    expect(report.eventsCount).toBe(0);
+    expect(report.warnings).toEqual([]);
+  });
+
+  test("show conta events relacionados", async () => {
+    const repo = new SessionsRepo(db);
+    repo.upsert({ sessionId: "sess-d", agent: "implementer" });
+    const events = new EventsRepo(db);
+    events.insert({
+      taskRunId: null,
+      sessionId: "sess-d",
+      traceId: null,
+      spanId: null,
+      kind: "task_start",
+      payload: {},
+    });
+    events.insert({
+      taskRunId: null,
+      sessionId: "sess-d",
+      traceId: null,
+      spanId: null,
+      kind: "task_finish",
+      payload: {},
+    });
+
+    const { stdout } = await captureOutput(() =>
+      runSessionsShow({ dbPath, format: "json", sessionId: "sess-d" }),
+    );
+    const report = JSON.parse(stdout) as SessionShowReport;
+    expect(report.eventsCount).toBe(2);
+  });
+
+  test("show emite warning quando compact_pending há > 7 dias", async () => {
+    const repo = new SessionsRepo(db);
+    repo.upsert({ sessionId: "sess-e", agent: "implementer" });
+    // Force state via SQL pra evitar lógica de validação de transição.
+    db.run("UPDATE sessions SET state='compact_pending', last_used_at=? WHERE session_id=?", [
+      "2026-01-01 00:00:00",
+      "sess-e",
+    ]);
+
+    const fixedNow = Date.parse("2026-04-30T00:00:00Z");
+    const { stdout } = await captureOutput(() =>
+      runSessionsShow({
+        dbPath,
+        format: "json",
+        sessionId: "sess-e",
+        nowMs: () => fixedNow,
+      }),
+    );
+    const report = JSON.parse(stdout) as SessionShowReport;
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toContain("compact_pending");
+    expect(report.warnings[0]).toContain("7 dias");
+  });
+
+  test("show retorna exit 1 + stderr error quando session não existe", async () => {
+    const { exit, stderr } = await captureOutput(() =>
+      runSessionsShow({ dbPath, format: "text", sessionId: "missing" }),
+    );
+    expect(exit).toBe(1);
+    expect(stderr).toContain("not found");
+  });
+});

--- a/tests/unit/cli/panic-lock.test.ts
+++ b/tests/unit/cli/panic-lock.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createPanicLock,
+  panicLockExists,
+  readPanicLock,
+  removePanicLock,
+} from "@clawde/cli/commands/panic";
+
+describe("cli/commands/panic lock helpers", () => {
+  let dir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "clawde-panic-lock-"));
+    lockPath = join(dir, "subdir", "panic.lock");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("createPanicLock cria diretório pai e arquivo com info", () => {
+    const info = createPanicLock(lockPath, "manual operator");
+    expect(existsSync(lockPath)).toBe(true);
+    expect(info.reason).toBe("manual operator");
+    expect(info.pid).toBe(process.pid);
+    expect(info.hostname.length).toBeGreaterThan(0);
+    expect(info.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    const persisted = JSON.parse(readFileSync(lockPath, "utf-8")) as {
+      reason: string;
+      pid: number;
+    };
+    expect(persisted.reason).toBe("manual operator");
+    expect(persisted.pid).toBe(process.pid);
+  });
+
+  test("createPanicLock é idempotente — segunda chamada preserva info original", () => {
+    const first = createPanicLock(lockPath, "first");
+    const second = createPanicLock(lockPath, "second");
+    expect(second.reason).toBe("first");
+    expect(second.ts).toBe(first.ts);
+    expect(second.pid).toBe(first.pid);
+  });
+
+  test("createPanicLock sem reason omite o campo", () => {
+    const info = createPanicLock(lockPath);
+    expect(info.reason).toBeUndefined();
+    const persisted = JSON.parse(readFileSync(lockPath, "utf-8")) as Record<string, unknown>;
+    expect(persisted.reason).toBeUndefined();
+  });
+
+  test("panicLockExists reflete estado do filesystem", () => {
+    expect(panicLockExists(lockPath)).toBe(false);
+    createPanicLock(lockPath);
+    expect(panicLockExists(lockPath)).toBe(true);
+  });
+
+  test("readPanicLock retorna info gravada", () => {
+    createPanicLock(lockPath, "halt for incident");
+    const info = readPanicLock(lockPath);
+    expect(info.reason).toBe("halt for incident");
+    expect(info.pid).toBe(process.pid);
+  });
+
+  test("removePanicLock é idempotente — no-op se ausente", () => {
+    expect(() => removePanicLock(lockPath)).not.toThrow();
+    createPanicLock(lockPath);
+    removePanicLock(lockPath);
+    expect(panicLockExists(lockPath)).toBe(false);
+    expect(() => removePanicLock(lockPath)).not.toThrow();
+  });
+});

--- a/tests/unit/cli/panic-systemd.test.ts
+++ b/tests/unit/cli/panic-systemd.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { fakeSystemdController } from "@clawde/cli/commands/panic";
+
+describe("cli/commands/panic fakeSystemdController", () => {
+  test("stop registra call e marca unit como inativa", async () => {
+    const sd = fakeSystemdController();
+    sd.setActive("clawde-receiver", true);
+    expect(await sd.isActive("clawde-receiver")).toBe(true);
+
+    const r = await sd.stop("clawde-receiver");
+    expect(r.ok).toBe(true);
+    expect(await sd.isActive("clawde-receiver")).toBe(false);
+    expect(sd.calls.map((c) => `${c.op}:${c.unit}`)).toEqual([
+      "isActive:clawde-receiver",
+      "stop:clawde-receiver",
+      "isActive:clawde-receiver",
+    ]);
+  });
+
+  test("start marca unit como ativa", async () => {
+    const sd = fakeSystemdController();
+    expect(await sd.isActive("clawde-worker")).toBe(false);
+    const r = await sd.start("clawde-worker");
+    expect(r.ok).toBe(true);
+    expect(await sd.isActive("clawde-worker")).toBe(true);
+  });
+
+  test("failOn faz operação retornar ok:false com detail opcional", async () => {
+    const sd = fakeSystemdController();
+    sd.failOn("stop", "clawde-receiver", "Failed: unit not found.");
+    const r = await sd.stop("clawde-receiver");
+    expect(r.ok).toBe(false);
+    expect(r.detail).toBe("Failed: unit not found.");
+  });
+
+  test("failOn sem detail retorna ok:false sem detail", async () => {
+    const sd = fakeSystemdController();
+    sd.failOn("start", "clawde-receiver");
+    const r = await sd.start("clawde-receiver");
+    expect(r.ok).toBe(false);
+    expect(r.detail).toBeUndefined();
+  });
+
+  test("isActive default = false pra unit não setada", async () => {
+    const sd = fakeSystemdController();
+    expect(await sd.isActive("never-set")).toBe(false);
+  });
+
+  test("calls acumula em ordem cronológica", async () => {
+    const sd = fakeSystemdController();
+    await sd.start("a.service");
+    await sd.stop("a.service");
+    await sd.isActive("a.service");
+    expect(sd.calls).toEqual([
+      { op: "start", unit: "a.service" },
+      { op: "stop", unit: "a.service" },
+      { op: "isActive", unit: "a.service" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Sub-fase P3.2 da Wave 5: implementa os 5 comandos CLI operacionais que faltavam pra cobrir RF-12 (REQUIREMENTS).

| Task | Comando | Tests |
|------|---------|-------|
| T-104a | `createPanicLock`/`panicLockExists`/`removePanicLock` helpers | 6/0 |
| T-104b | `SystemdController` real + fake (injetável) | 6/0 |
| T-104c | `clawde panic-stop` (lock + stop receiver/worker.path + event panic_stop) | 3/0 |
| T-105 | `clawde panic-resume` (diagnose ok ⇒ unlock + start receiver) | 4/0 |
| T-106 | `clawde diagnose <db\|quota\|oauth\|sandbox\|agents\|all>` | 8/0 |
| T-107 | `clawde sessions list` | (em sessões 6/0) |
| T-108 | `clawde sessions show <id>` (com warning compact_pending >7d) | (idem) |
| T-109 | `clawde config show` (resolved + env overrides) | (em config 6/0) |
| T-110 | `clawde config validate <path>` (zod issues estruturadas) | (idem) |
| T-111 | Cut `forget` + `audit verify/export` de RF-12 + BLUEPRINT §6.1 | docs |

## Decisões

- **`SystemdController`**: wrapper injetável real/fake. Permite teste end-to-end de panic-stop/resume sem systemd no test runner.
- **Lock idempotente**: `createPanicLock` 2x preserva info original; `removePanicLock` no arquivo ausente é no-op. Per BLUEPRINT §6.2.
- **Diagnose status mapping**: `ok|warn|error` → exit 0/1/2; `all` agrega como pior dos sub-checks.
- **Panic-resume não-idempotente por design**: lock removido antes do start; falha de start retorna exit 2 com lock já removido pra estado conhecido pra investigação.
- **Compact_pending warning**: detecta sessões esquecidas há >7d com `nowMs` injetável pra teste determinístico.
- **Config decoupling**: `runConfigValidate` usa `env: {}` pra isolar overrides do test env.

## Atomic commits

10 commits no branch (per spec: 1 task = 1 commit, exceto T-107+T-108 e T-109+T-110 que ficam juntos por proximidade conceitual e arquivo único). Wire-up em `main.ts` é commit final integrador.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` (sem novos warnings)
- [x] `bun test` 683/683 pass (1 reprodução do flaky histórico `findExpiredLeases` na 1ª rodada, sumiu na 2ª — comportamento conhecido)
- [x] Cobertura por task: panic-lock 6/0, panic-systemd 6/0, panic-stop 3/0, panic-resume 4/0, diagnose 8/0, sessions 6/0, config 6/0

## Out of scope

- `clawde forget` / `clawde audit verify|export`: cortados de RF-12 (T-111). Reintroduzir requer ADR.
- `clawde reflect`: já entregue em P3.4 (PR #20).
- Wire de panic em alerta Telegram: deferido — `runPanicStop` registra evento `panic_stop`, alerta pode ser added quando canal tiver wire-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)