### PR TITLE
P3.6: SDK real validation (T-122..T-124)

### DIFF
--- a/.github/workflows/sdk-real.yml
+++ b/.github/workflows/sdk-real.yml
@@ -1,0 +1,42 @@
+name: sdk-real
+
+on:
+  push:
+    paths:
+      - "src/sdk/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/sdk-real.yml"
+  pull_request:
+    paths:
+      - "src/sdk/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/sdk-real.yml"
+
+jobs:
+  real-sdk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CLAWDE_TEST_REAL_SDK: "1"
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Guard secret presence
+        run: |
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "CLAUDE_CODE_OAUTH_TOKEN secret is required for sdk-real workflow."
+            exit 1
+          fi
+
+      - name: Run real SDK integration tests
+        run: bun test --grep real-sdk

--- a/STATUS.md
+++ b/STATUS.md
@@ -52,7 +52,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | merged, PR #25, 2026-04-30 | #25 |
 | P3.4 | `task/P3.4-reflect-job` | T-112..T-115 | claude | codex | merged, PR #20, 2026-04-30 | #20 |
 | P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | merged, PR #24, 2026-04-30 | #24 |
-| P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | in-progress, codex | — |
+| P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | in-review, PR #26, 2026-04-30 | #26 |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | pending | — |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | pending | — |
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | pending | — |
@@ -250,9 +250,9 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-121 — merged, PR #24, 2026-04-30
 
 ### P3.6 — SDK real validation
-- [ ] T-122 — in-progress, codex
-- [ ] T-123 — pending
-- [ ] T-124 — pending
+- [x] T-122 — in-review, PR #26, 2026-04-30
+- [x] T-123 — in-review, PR #26, 2026-04-30
+- [x] T-124 — in-review, PR #26, 2026-04-30
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -52,7 +52,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.2 | `task/P3.2-cli-ops` | T-104a/b/c, T-105..T-111 | claude | codex | merged, PR #25, 2026-04-30 | #25 |
 | P3.4 | `task/P3.4-reflect-job` | T-112..T-115 | claude | codex | merged, PR #20, 2026-04-30 | #20 |
 | P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | merged, PR #24, 2026-04-30 | #24 |
-| P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | pending | — |
+| P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | in-progress, codex | — |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | pending | — |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | pending | — |
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | pending | — |
@@ -250,7 +250,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-121 — merged, PR #24, 2026-04-30
 
 ### P3.6 — SDK real validation
-- [ ] T-122 — pending
+- [ ] T-122 — in-progress, codex
 - [ ] T-123 — pending
 - [ ] T-124 — pending
 

--- a/deploy/systemd/clawde-smoke.service
+++ b/deploy/systemd/clawde-smoke.service
@@ -5,7 +5,7 @@ Description=Clawde smoke test diário
 Type=oneshot
 WorkingDirectory=%h/.clawde
 EnvironmentFile=-%h/.clawde/config/clawde.env
-ExecStart=%h/.clawde/dist/clawde smoke-test --output json
+ExecStart=%h/.clawde/dist/clawde smoke-test --output json --include-sdk-ping
 
 # Hardening idêntico ao worker (BEST_PRACTICES §10.4)
 PrivateTmp=yes

--- a/tests/integration/sdk-real.test.ts
+++ b/tests/integration/sdk-real.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { RealAgentClient, parseRawMessage } from "@clawde/sdk";
+
+const RUN_REAL_SDK =
+  process.env.CLAWDE_TEST_REAL_SDK === "1" &&
+  process.env.CLAUDE_CODE_OAUTH_TOKEN !== undefined &&
+  process.env.CLAUDE_CODE_OAUTH_TOKEN.length > 0;
+
+const maybeTest = RUN_REAL_SDK ? test : test.skip;
+
+async function firstFrom<T>(iterable: AsyncIterable<T>): Promise<T> {
+  for await (const item of iterable) {
+    return item;
+  }
+  throw new Error("real-sdk stream returned no messages");
+}
+
+describe("integration: real-sdk", () => {
+  maybeTest("real-sdk ping returns assistant output", async () => {
+    const client = new RealAgentClient();
+    const result = await client.run({
+      prompt: "Reply with exactly: pong",
+      maxTurns: 1,
+    });
+
+    expect(result.stopReason).not.toBe("error");
+    expect(result.error).toBeNull();
+    expect(result.msgsConsumed).toBeGreaterThan(0);
+    expect(result.finalText.toLowerCase()).toContain("pong");
+  });
+
+  maybeTest("real-sdk parser handles current message shape", async () => {
+    const client = new RealAgentClient();
+    const first = await firstFrom(
+      client.stream({
+        prompt: "Reply with exactly: pong",
+        maxTurns: 1,
+      }),
+    );
+
+    expect(first.raw).toBeDefined();
+    const parsedAgain = parseRawMessage(first.raw);
+    expect(parsedAgain).not.toBeNull();
+    expect(parsedAgain?.role).toBe(first.role);
+  });
+});


### PR DESCRIPTION
Closes sub-phase P3.6 in EXECUTION_BACKLOG.md.

## Tasks included
- T-122: tests/integration/sdk-real.test.ts skipado por default
- T-123: workflow .github/workflows/sdk-real.yml
- T-124: smoke service diário com --include-sdk-ping

## What changed
Adicionei um teste de integração real do SDK com gate por ambiente (`CLAWDE_TEST_REAL_SDK=1` + `CLAUDE_CODE_OAUTH_TOKEN`), cobrindo ping real e validação de parser sobre shape atual de mensagem. Também incluí workflow dedicado para rodar esse teste real em alterações de `src/sdk/**` e atualizei o serviço systemd de smoke diário para incluir sdk ping.

## Acceptance criteria validated
- [x] T-122
- [x] T-123
- [x] T-124

## CI
- [x] `bun run typecheck`
- [x] `bun test tests/integration/sdk-real.test.ts tests/integration/smoke-test.test.ts` (7 pass, 2 skip)
- [ ] `bun run lint` clean no branch base (há erros preexistentes introduzidos antes desta sub-fase em arquivos de P3.2)

## Notes for reviewer
- Os testes `real-sdk` ficam skipados por default e só executam com ambos env vars setados.
- O workflow falha explicitamente se o secret `CLAUDE_CODE_OAUTH_TOKEN` não estiver definido.
- T-124 apenas ativa o caminho já implementado em T-121 no serviço diário.
