### PR TITLE
Wave audits: add wave 3 and wave 5 summaries

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -299,9 +299,9 @@ e produz `docs/wave-summaries/wave-N.md`.
 
 - [x] Wave 1 audit — done (reviewer: codex, docs/wave-summaries/wave-1.md, PR #27, 2026-05-01)
 - [x] Wave 2 audit — done (reviewer: claude, docs/wave-summaries/wave-2.md)
-- [ ] Wave 3 audit — pending (reviewer: codex)
+- [ ] Wave 3 audit — in-review (reviewer: codex, docs/wave-summaries/wave-3.md, PR #28, 2026-05-01)
 - [x] Wave 4 audit — done (reviewer: claude, docs/wave-summaries/wave-4.md, PR #23, 2026-04-30)
-- [ ] Wave 5 audit — pending (reviewer: codex)
+- [ ] Wave 5 audit — in-review (reviewer: codex, docs/wave-summaries/wave-5.md, PR #28, 2026-05-01)
 - [ ] Wave 6 audit — pending (reviewer: claude)
 
 ---

--- a/docs/wave-summaries/wave-3.md
+++ b/docs/wave-summaries/wave-3.md
@@ -1,0 +1,69 @@
+# Wave 3 Audit — Segurança core (P2.1, P2.2, P2.3, P2.4, P2.5)
+
+**Status**: ✅ Closed (2026-04-30)  
+**Reviewer**: Codex  
+**Sub-fases**: P2.1, P2.2, P2.3, P2.4, P2.5a, P2.5b (6/6 merged)
+
+## PRs (core da wave)
+
+| Sub-fase | PR | Merge commit | LOC | Tasks |
+|----------|----|----|----|-------|
+| P2.1 | [#7](https://github.com/Incavenuziano/Clawde/pull/7) | `5dcdd5c` | +350 / -106 | T-041..T-046 |
+| P2.2 | [#10](https://github.com/Incavenuziano/Clawde/pull/10) | `5f7e690` | +198 / -18 | T-047..T-053 |
+| P2.3 | [#15](https://github.com/Incavenuziano/Clawde/pull/15) | `b5ca098` | +320 / -18 | T-054..T-057 |
+| P2.4 | [#16](https://github.com/Incavenuziano/Clawde/pull/16) | `bcc91e3` | +543 / -27 | T-058..T-062 |
+| P2.5a | [#11](https://github.com/Incavenuziano/Clawde/pull/11) | `dbf02f7` | +618 / -22 | T-063..T-068, T-077, T-078 |
+| P2.5b | [#12](https://github.com/Incavenuziano/Clawde/pull/12) | `028b21d` | +235 / -9 | T-069..T-076 |
+| **Total** | 6 | — | **+2264 / -200** | **38 tasks** |
+
+## Followups pós-review da wave
+
+| Followup | PR | Merge commit | LOC | Motivo |
+|----------|----|----|----|--------|
+| Bash/level alignment | [#13](https://github.com/Incavenuziano/Clawde/pull/13) | `60cfc9c` | +97 / -9 | Resolver mismatch entre perfis e fail-safe de sandbox (`level>=2` sem Bash) |
+| Read allowlist | [#14](https://github.com/Incavenuziano/Clawde/pull/14) | `f91b10c` | +144 / -0 | Fechar vetor de exfiltração para agentes com entrada adversarial auto-resposta |
+| **Total followups** | 2 | — | **+241 / -9** | hardening pós-review |
+
+## Métricas
+
+- Test count: **586** (fim da Wave 2) → **606** (fim da Wave 3), **+20**.
+- Arquivos alterados (soma por PRs core): 58.
+- Arquivos alterados (core + followups): 74.
+- Novos artefatos centrais:
+  - workspace ephemeral + cleanup/reconcile robusto;
+  - hooks de sandbox em tool use;
+  - injection de contexto externo (guardrails) e review com contexto fresco;
+  - loader de agentes via `AGENT.md` + wiring runtime dos gates.
+
+## Decisões notáveis
+
+### P2.1 — Cleanup de workspace garantido por `try/finally`
+
+O bug bloqueante identificado em review foi corrigido para garantir limpeza de worktree em todos os caminhos (sucesso, 429/defer, erro genérico), evitando leak permanente em `/tmp/clawde-<runId>/`.
+
+### P2.2 + P2.5a — Gates de sandbox viraram runtime real
+
+O fluxo saiu de “só em testes” para execução efetiva no runner: `allowedTools`/`disallowedTools`/`maxTurns` mapeados e `makePreToolUseHandler` registrado no loop de stream.
+
+### P2.5b + followups (#13/#14) — Perfil de agentes alinhado ao threat model atual
+
+Após review cruzado, os ajustes pós-wave consolidaram:
+- agentes que precisam shell (`implementer`/`verifier`) em `level=1` até existir Estratégia A;
+- agentes com input adversarial e auto-resposta (`telegram-bot`, `github-pr-handler`) com `allowed_reads = []` (fail-closed).
+
+## Critérios de validação
+
+- CI verde nos PRs da wave (com o flaky histórico de leases aparecendo de forma intermitente em algumas rodadas, sem regressão estrutural atribuída aos merges da wave).
+- Revisão cruzada aplicada em todas as sub-fases (implementação e review alternados entre Claude/Codex).
+- Tasks de segurança com aprovação adicional do operador quando aplicável (P2.2, P2.5b e followups de hardening).
+
+## Followups abertos
+
+- Estratégia A (wrapper de subprocesso com isolamento mais forte) para reabilitar `level>=2` com Bash de forma consistente.
+- Refinar `allowed_reads` para agentes internos (hoje permissivo por legado em parte dos perfis).
+- Cleanup arquitetural menor: remover redundâncias de tipos/arquivos paralelos no stack de agentes.
+
+## Resultado
+
+**Wave 3 fechada.**  
+O sistema passou a ter o núcleo de segurança operacional ativo em runtime: workspace efêmero confiável, gates de tools no runner, perfis de agentes carregados de forma tipada e controles pós-review para reduzir exfiltração em fluxos com input adversarial.

--- a/docs/wave-summaries/wave-5.md
+++ b/docs/wave-summaries/wave-5.md
@@ -1,0 +1,63 @@
+# Wave 5 Audit — Alinhamento (P3.1, P3.2, P3.4, P3.5, P3.6)
+
+**Status**: ✅ Closed (2026-05-01)  
+**Reviewer**: Codex  
+**Sub-fases**: P3.1, P3.2, P3.4, P3.5, P3.6 (5/5 merged)
+
+## PRs
+
+| Sub-fase | PR | Merge commit | LOC | Tasks |
+|----------|----|----|----|-------|
+| P3.1 | [#18](https://github.com/Incavenuziano/Clawde/pull/18) | `7c4daa9` | +63 / -16 | T-101..T-103 |
+| P3.2 | [#25](https://github.com/Incavenuziano/Clawde/pull/25) | `a127e44` | +2067 / -23 | T-104a/b/c, T-105..T-111 |
+| P3.4 | [#20](https://github.com/Incavenuziano/Clawde/pull/20) | `8ed0371` | +475 / -7 | T-112..T-115 |
+| P3.5 | [#24](https://github.com/Incavenuziano/Clawde/pull/24) | `a64d3e8` | +505 / -12 | T-116..T-121 |
+| P3.6 | [#26](https://github.com/Incavenuziano/Clawde/pull/26) | `e0063ea` | +93 / -5 | T-122..T-124 |
+| **Total** | 5 | — | **+3203 / -63** | **26 tasks** |
+
+## Métricas
+
+- Test count: **640** (fim da Wave 4) → **690** (fim da Wave 5), **+50**.
+- Arquivos alterados (soma por PR): 40.
+- Novos blocos operacionais:
+  - CLI de operação (`diagnose`, `panic-stop`, `panic-resume`, `sessions`, `config`);
+  - job de reflexão estruturada (`reflect`) e serviço systemd dedicado;
+  - smoke-test com checks de worker/sandbox/SDK e integração em serviço;
+  - suíte real-SDK opcional em CI com guards de credencial.
+
+## Decisões notáveis
+
+### P3.2 — CLI operacional completa e testável
+
+A wave ganhou comandos de operação e diagnóstico com desenho testável (controller injetável para systemd e lock de pânico idempotente no stop), além de `config show` com origem por campo (`env > toml > default`), reduzindo ambiguidade de troubleshooting.
+
+### P3.4 — Reflector como fluxo estruturado, não prompt ad hoc
+
+O `reflect` passou a montar prompt determinístico com janela de eventos/observações e enfileirar via receiver com dedup, preservando trilha operacional.
+
+### P3.5 — Smoke alinhado ao runtime real, sem acoplamento indevido a config global
+
+O blocker de regressão E2E foi corrigido: checks que dependiam implicitamente de `HOME`/TOML global passaram a derivar contexto por `dbPath` e ambiente de smoke controlado, restaurando o contrato dos testes de ciclo de vida.
+
+### P3.6 — Real SDK validado sem quebrar runs padrão
+
+Foram adicionados testes reais condicionais (`CLAWDE_TEST_REAL_SDK=1` + token) e workflow dedicado, mantendo o comportamento default estável (skips esperados quando credenciais não existem).
+
+## Critérios de validação
+
+- PRs da wave com revisão cruzada conforme alternância Claude/Codex.
+- CI limpa reportada nos merges da wave:
+  - P3.2: 685/0 (com flaky histórico oscilando em rodada anterior);
+  - P3.6: 690/0 com 2 skips esperados (real-SDK gated).
+- Regressão E2E de smoke (introduzida em P3.5 inicial) resolvida antes do merge final.
+
+## Followups abertos
+
+- Documentar de forma explícita a convenção de `CLAWDE_CONFIG=\"\"` usada em ambiente de smoke.
+- Endurecer comportamento do workflow real-SDK em forks sem secret (pular explicitamente vs falhar).
+- Continuar monitorando o flaky histórico de lease expiry até estabilização completa.
+
+## Resultado
+
+**Wave 5 fechada.**  
+A camada operacional ficou significativamente mais madura: comandos de resposta a incidente, diagnóstico e inspeção; rotina de reflexão automatizada; smoke service mais fiel ao runtime; e validação real de SDK no pipeline controlado por credenciais.


### PR DESCRIPTION
Closes Wave 3 and Wave 5 audits in STATUS.md.

## Tasks included
- Wave 3 audit (reviewer: codex)
- Wave 5 audit (reviewer: codex)

## What changed
- Added `docs/wave-summaries/wave-3.md` consolidating closure of P2.1..P2.5 plus post-review hardening followups (#13/#14).
- Added `docs/wave-summaries/wave-5.md` consolidating closure of P3.1/P3.2/P3.4/P3.5/P3.6.
- Captured merged PRs, merge commits, LOC totals, test-count progression, notable architecture decisions, and open followups.

## Acceptance criteria validated
- [x] Wave 3 merged branches summarized with traceable PR links
- [x] Wave 5 merged branches summarized with traceable PR links
- [x] Audit artifacts created at `docs/wave-summaries/wave-3.md` and `docs/wave-summaries/wave-5.md`

## CI
- [x] Docs-only change (no runtime code path changes)

## Notes for reviewer
- This PR only adds wave audit documentation; runtime behavior is unchanged.

🤖 Implemented by Codex
