### PR TITLE
P6.2: DB integrity automation

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -54,7 +54,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | merged, PR #24, 2026-04-30 | #24 |
 | P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | merged, PR #26, 2026-05-01 | #26 |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | merged, PR #29, 2026-05-01 | #29 |
-| P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | pending | — |
+| P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | in-progress, codex | — |
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | pending | — |
 | P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | pending | — |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | pending | — |
@@ -264,9 +264,9 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-127 — merged, PR #29, 2026-05-01 — coverage gate
 
 ### P6.2 — DB integrity automation
-- [ ] T-128 — pending
-- [ ] T-129 — pending
-- [ ] T-130 — pending
+- [ ] T-128 — in-progress, codex
+- [ ] T-129 — in-progress, codex
+- [ ] T-130 — in-progress, codex
 
 ### P6.3 — Events retention
 - [ ] T-131 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -54,7 +54,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.5 | `task/P3.5-smoke-service` | T-116..T-121 | codex | claude | merged, PR #24, 2026-04-30 | #24 |
 | P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | merged, PR #26, 2026-05-01 | #26 |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | merged, PR #29, 2026-05-01 | #29 |
-| P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | in-progress, codex | — |
+| P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | in-review, PR #30 | #30 |
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | pending | — |
 | P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | pending | — |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | pending | — |
@@ -264,9 +264,9 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-127 — merged, PR #29, 2026-05-01 — coverage gate
 
 ### P6.2 — DB integrity automation
-- [ ] T-128 — in-progress, codex
-- [ ] T-129 — in-progress, codex
-- [ ] T-130 — in-progress, codex
+- [ ] T-128 — in-review, codex, PR #30
+- [ ] T-129 — in-review, codex, PR #30
+- [ ] T-130 — in-review, codex, PR #30
 
 ### P6.3 — Events retention
 - [ ] T-131 — pending

--- a/deploy/systemd/clawde-integrity.service
+++ b/deploy/systemd/clawde-integrity.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Clawde DB integrity check diário
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/.clawde
+EnvironmentFile=-%h/.clawde/config/clawde.env
+ExecStart=%h/.clawde/dist/clawde diagnose db --output json
+
+# Hardening idêntico ao worker (BEST_PRACTICES §10.4)
+PrivateTmp=yes
+ProtectHome=read-only
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+ReadWritePaths=%h/.clawde
+
+[Install]
+WantedBy=default.target

--- a/deploy/systemd/clawde-integrity.timer
+++ b/deploy/systemd/clawde-integrity.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Clawde DB integrity check agendado (diário 02:30 local)
+
+[Timer]
+OnCalendar=*-*-* 02:30:00
+Unit=clawde-integrity.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/src/cli/commands/diagnose.ts
+++ b/src/cli/commands/diagnose.ts
@@ -12,6 +12,11 @@ import { dirname, join } from "node:path";
 import { loadAllAgentDefinitions } from "@clawde/agents";
 import { OAuthLoadError, getTokenExpiry, loadOAuthToken } from "@clawde/auth";
 import { closeDb, openDb } from "@clawde/db/client";
+import {
+  SLOW_INTEGRITY_CHECK_MS,
+  isDbIntegrityOk,
+  runDbIntegrityChecks,
+} from "@clawde/db/integrity";
 import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { DEFAULT_TRACKER_CONFIG, QuotaTracker } from "@clawde/quota";
 import { type OutputFormat, emit } from "../output.ts";
@@ -62,13 +67,15 @@ export async function runDiagnose(options: DiagnoseOptions): Promise<number> {
 
   emit(options.format, report, (d) => {
     const r = d as DiagnoseReport;
-    const lines = r.checks.map(
-      (c) => `[${statusBadge(c.status)}] ${c.name}: ${c.detail ?? ""}`,
-    );
+    const lines = r.checks.map((c) => `[${statusBadge(c.status)}] ${c.name}: ${c.detail ?? ""}`);
     lines.push(`overall: ${statusBadge(r.status)}`);
     return lines.join("\n");
   });
 
+  if (options.subject === "db" && status !== "ok") {
+    // T-128: `diagnose db` deve retornar 1 quando qualquer PRAGMA divergir.
+    return 1;
+  }
   return statusToExit(status);
 }
 
@@ -94,14 +101,26 @@ function checkDb(dbPath: string): DiagnoseCheck {
   try {
     const db = openDb(dbPath);
     try {
-      const row = db.query<{ integrity_check: string }, []>("PRAGMA integrity_check").get();
-      if (row?.integrity_check === "ok") {
-        return { name: "db.integrity", status: "ok", detail: "PRAGMA integrity_check ok" };
+      const report = runDbIntegrityChecks(db);
+      const detail = formatDbIntegrityDetail(report);
+      if (!isDbIntegrityOk(report)) {
+        return {
+          name: "db.integrity",
+          status: "error",
+          detail,
+        };
+      }
+      if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
+        return {
+          name: "db.integrity",
+          status: "warn",
+          detail,
+        };
       }
       return {
         name: "db.integrity",
-        status: "error",
-        detail: row?.integrity_check ?? "unknown",
+        status: "ok",
+        detail,
       };
     } finally {
       closeDb(db);
@@ -109,6 +128,26 @@ function checkDb(dbPath: string): DiagnoseCheck {
   } catch (err) {
     return { name: "db.integrity", status: "error", detail: (err as Error).message };
   }
+}
+
+function formatDbIntegrityDetail(report: ReturnType<typeof runDbIntegrityChecks>): string {
+  const parts = [
+    `integrity_check=${report.integrityCheck}`,
+    `quick_check=${report.quickCheck}`,
+    `foreign_key_violations=${report.foreignKeyViolations.length}`,
+    `elapsed_ms=${report.elapsedMs}`,
+  ];
+  if (report.foreignKeyViolations.length > 0) {
+    const sample = report.foreignKeyViolations
+      .slice(0, 3)
+      .map((v) => `${v.table}#${v.rowid}->${v.parent}(${v.fkid})`)
+      .join(", ");
+    parts.push(`fk_diff_sample=${sample}`);
+  }
+  if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
+    parts.push(`slow_check_warn=>${SLOW_INTEGRITY_CHECK_MS}ms`);
+  }
+  return parts.join("; ");
 }
 
 function checkQuota(dbPath: string): DiagnoseCheck {

--- a/src/db/integrity.ts
+++ b/src/db/integrity.ts
@@ -1,0 +1,40 @@
+import type { ClawdeDatabase } from "./client.ts";
+
+export interface ForeignKeyViolation {
+  readonly table: string;
+  readonly rowid: number;
+  readonly parent: string;
+  readonly fkid: number;
+}
+
+export interface DbIntegrityReport {
+  readonly integrityCheck: string;
+  readonly quickCheck: string;
+  readonly foreignKeyViolations: ReadonlyArray<ForeignKeyViolation>;
+  readonly elapsedMs: number;
+}
+
+export const SLOW_INTEGRITY_CHECK_MS = 1_000;
+
+export function runDbIntegrityChecks(db: ClawdeDatabase): DbIntegrityReport {
+  const startedAt = performance.now();
+  const integrityRow = db.query<{ integrity_check: string }, []>("PRAGMA integrity_check").get();
+  const quickRow = db.query<{ quick_check: string }, []>("PRAGMA quick_check").get();
+  const foreignKeyViolations = db.query<ForeignKeyViolation, []>("PRAGMA foreign_key_check").all();
+  const elapsedMs = Math.round(performance.now() - startedAt);
+
+  return {
+    integrityCheck: integrityRow?.integrity_check ?? "(no result)",
+    quickCheck: quickRow?.quick_check ?? "(no result)",
+    foreignKeyViolations,
+    elapsedMs,
+  };
+}
+
+export function isDbIntegrityOk(report: DbIntegrityReport): boolean {
+  return (
+    report.integrityCheck === "ok" &&
+    report.quickCheck === "ok" &&
+    report.foreignKeyViolations.length === 0
+  );
+}

--- a/src/db/migrations/007_event_kind_db_corrupted.down.sql
+++ b/src/db/migrations/007_event_kind_db_corrupted.down.sql
@@ -1,0 +1,93 @@
+-- Migration 007 (DOWN) — remove `db_corrupted` event kind.
+
+CREATE TABLE events_old (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           TEXT    NOT NULL DEFAULT (datetime('now')),
+  task_run_id  INTEGER REFERENCES task_runs(id) ON DELETE SET NULL,
+  session_id   TEXT    REFERENCES sessions(session_id) ON DELETE SET NULL,
+  trace_id     TEXT,
+  span_id      TEXT,
+  kind         TEXT    NOT NULL
+               CHECK (kind IN (
+                 'enqueue',
+                 'auth_fail',
+                 'rate_limit_hit',
+                 'dedup_skip',
+                 'task_deferred',
+                 'task_start',
+                 'task_finish',
+                 'task_fail',
+                 'lease_expired',
+                 'quarantine_enter',
+                 'quarantine_exit',
+                 'claude_invocation_start',
+                 'claude_invocation_end',
+                 'tool_use',
+                 'tool_result',
+                 'tool_blocked',
+                 'compact_triggered',
+                 'quota_threshold_crossed',
+                 'quota_reset',
+                 'peak_multiplier_applied',
+                 'quota_429_observed',
+                 'oauth_refresh_attempt',
+                 'oauth_refresh_success',
+                 'oauth_expiry_warning',
+                 'auth.telegram_reject',
+                 'auth.telegram_user_blocked',
+                 'sandbox_init',
+                 'sandbox_violation',
+                 'migration_start',
+                 'migration_end',
+                 'migration_fail',
+                 'maintenance_start',
+                 'maintenance_end',
+                 'smoke.sdk_real_ping_ok',
+                 'smoke.sdk_real_ping_fail',
+                 'prompt_guard_alert',
+                 'panic_stop',
+                 'hook_error',
+                 'hook_timeout',
+                 'lesson',
+                 'reflection_start',
+                 'reflection_end',
+                 'review.implementer.start',
+                 'review.implementer.end',
+                 'review.spec.start',
+                 'review.spec.verdict',
+                 'review.quality.start',
+                 'review.quality.verdict',
+                 'review.pipeline.complete',
+                 'review.pipeline.exhausted',
+                 'agent_invalid',
+                 'sdk_auth_error',
+                 'sdk_network_error'
+               )),
+  payload      TEXT    NOT NULL DEFAULT '{}'
+               CHECK (json_valid(payload))
+);
+
+INSERT INTO events_old
+SELECT *
+FROM events
+WHERE kind NOT IN ('db_corrupted');
+
+DROP TABLE events;
+ALTER TABLE events_old RENAME TO events;
+
+CREATE INDEX idx_events_task_ts ON events(task_run_id, ts);
+CREATE INDEX idx_events_trace ON events(trace_id) WHERE trace_id IS NOT NULL;
+CREATE INDEX idx_events_kind_ts ON events(kind, ts);
+
+CREATE TRIGGER events_no_update
+BEFORE UPDATE ON events
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only');
+END;
+
+CREATE TRIGGER events_no_delete
+BEFORE DELETE ON events
+WHEN (SELECT COUNT(*) FROM _retention_grant) = 0
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only outside retention job');
+END;

--- a/src/db/migrations/007_event_kind_db_corrupted.up.sql
+++ b/src/db/migrations/007_event_kind_db_corrupted.up.sql
@@ -1,0 +1,94 @@
+-- Migration 007 (UP) — add `db_corrupted` event kind.
+-- P6.2 T-129: worker startup emits `db_corrupted` when integrity checks fail.
+
+CREATE TABLE events_new (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           TEXT    NOT NULL DEFAULT (datetime('now')),
+  task_run_id  INTEGER REFERENCES task_runs(id) ON DELETE SET NULL,
+  session_id   TEXT    REFERENCES sessions(session_id) ON DELETE SET NULL,
+  trace_id     TEXT,
+  span_id      TEXT,
+  kind         TEXT    NOT NULL
+               CHECK (kind IN (
+                 'enqueue',
+                 'auth_fail',
+                 'rate_limit_hit',
+                 'dedup_skip',
+                 'task_deferred',
+                 'task_start',
+                 'task_finish',
+                 'task_fail',
+                 'lease_expired',
+                 'quarantine_enter',
+                 'quarantine_exit',
+                 'claude_invocation_start',
+                 'claude_invocation_end',
+                 'tool_use',
+                 'tool_result',
+                 'tool_blocked',
+                 'compact_triggered',
+                 'quota_threshold_crossed',
+                 'quota_reset',
+                 'peak_multiplier_applied',
+                 'quota_429_observed',
+                 'oauth_refresh_attempt',
+                 'oauth_refresh_success',
+                 'oauth_expiry_warning',
+                 'auth.telegram_reject',
+                 'auth.telegram_user_blocked',
+                 'sandbox_init',
+                 'sandbox_violation',
+                 'migration_start',
+                 'migration_end',
+                 'migration_fail',
+                 'maintenance_start',
+                 'maintenance_end',
+                 'smoke.sdk_real_ping_ok',
+                 'smoke.sdk_real_ping_fail',
+                 'prompt_guard_alert',
+                 'panic_stop',
+                 'db_corrupted',
+                 'hook_error',
+                 'hook_timeout',
+                 'lesson',
+                 'reflection_start',
+                 'reflection_end',
+                 'review.implementer.start',
+                 'review.implementer.end',
+                 'review.spec.start',
+                 'review.spec.verdict',
+                 'review.quality.start',
+                 'review.quality.verdict',
+                 'review.pipeline.complete',
+                 'review.pipeline.exhausted',
+                 'agent_invalid',
+                 'sdk_auth_error',
+                 'sdk_network_error'
+               )),
+  payload      TEXT    NOT NULL DEFAULT '{}'
+               CHECK (json_valid(payload))
+);
+
+INSERT INTO events_new
+SELECT *
+FROM events;
+
+DROP TABLE events;
+ALTER TABLE events_new RENAME TO events;
+
+CREATE INDEX idx_events_task_ts ON events(task_run_id, ts);
+CREATE INDEX idx_events_trace ON events(trace_id) WHERE trace_id IS NOT NULL;
+CREATE INDEX idx_events_kind_ts ON events(kind, ts);
+
+CREATE TRIGGER events_no_update
+BEFORE UPDATE ON events
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only');
+END;
+
+CREATE TRIGGER events_no_delete
+BEFORE DELETE ON events
+WHEN (SELECT COUNT(*) FROM _retention_grant) = 0
+BEGIN
+  SELECT RAISE(FAIL, 'events is append-only outside retention job');
+END;

--- a/src/domain/event.ts
+++ b/src/domain/event.ts
@@ -50,6 +50,7 @@ export const EVENT_KIND_VALUES = [
   // security
   "prompt_guard_alert",
   "panic_stop",
+  "db_corrupted",
   // hooks (BLUEPRINT §4.5)
   "hook_error",
   "hook_timeout",

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -3,6 +3,11 @@ import { basename, dirname, join } from "node:path";
 import { AgentDefinitionError, loadAllAgentDefinitionsWithWarnings } from "@clawde/agents";
 import { loadConfig } from "@clawde/config";
 import { closeDb, openDb } from "@clawde/db/client";
+import {
+  SLOW_INTEGRITY_CHECK_MS,
+  isDbIntegrityOk,
+  runDbIntegrityChecks,
+} from "@clawde/db/integrity";
 import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
 import { EventsRepo } from "@clawde/db/repositories/events";
 import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
@@ -40,6 +45,48 @@ export interface LoopResult {
   readonly exitReason: LoopExitReason;
 }
 
+function assertStartupDbIntegrity(
+  db: ReturnType<typeof openDb>,
+  logger: ReturnType<typeof createLogger>,
+): void {
+  const report = runDbIntegrityChecks(db);
+  if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
+    logger.warn("startup integrity_check slow", {
+      elapsed_ms: report.elapsedMs,
+      threshold_ms: SLOW_INTEGRITY_CHECK_MS,
+    });
+  }
+  if (isDbIntegrityOk(report)) {
+    return;
+  }
+
+  const payload = {
+    integrity_check: report.integrityCheck,
+    quick_check: report.quickCheck,
+    foreign_key_violations: report.foreignKeyViolations.length,
+    elapsed_ms: report.elapsedMs,
+  } as const;
+  try {
+    new EventsRepo(db).insert({
+      taskRunId: null,
+      sessionId: null,
+      traceId: null,
+      spanId: null,
+      kind: "db_corrupted",
+      payload,
+    });
+  } catch (err) {
+    logger.error("failed to persist db_corrupted event", {
+      error: (err as Error).message,
+    });
+  }
+
+  logger.error("db integrity failed; entering readonly mode", payload);
+  throw new Error(
+    `db integrity failed (integrity_check=${report.integrityCheck}, quick_check=${report.quickCheck}, fk=${report.foreignKeyViolations.length})`,
+  );
+}
+
 export async function runProcessLoop(deps: RunnerDeps, maxTasks: number): Promise<LoopResult> {
   let processed = 0;
   while (processed < maxTasks) {
@@ -63,6 +110,7 @@ export async function bootstrap(
   const db = openDb(dbPath);
   try {
     applyPending(db, defaultMigrationsDir());
+    assertStartupDbIntegrity(db, logger);
     const tasksRepo = new TasksRepo(db);
     const runsRepo = new TaskRunsRepo(db);
     const eventsRepo = new EventsRepo(db);
@@ -154,5 +202,10 @@ export async function bootstrap(
 }
 
 if (import.meta.main) {
-  bootstrap().then(() => process.exit(0));
+  bootstrap()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error((err as Error).message);
+      process.exit(1);
+    });
 }

--- a/tests/integration/diagnose.test.ts
+++ b/tests/integration/diagnose.test.ts
@@ -2,10 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  type DiagnoseReport,
-  runDiagnose,
-} from "@clawde/cli/commands/diagnose";
+import { type DiagnoseReport, runDiagnose } from "@clawde/cli/commands/diagnose";
 import { closeDb, openDb } from "@clawde/db/client";
 import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
 
@@ -53,6 +50,29 @@ describe("cli/commands/diagnose", () => {
     expect(report.subject).toBe("db");
     expect(report.status).toBe("ok");
     expect(report.checks[0]?.name).toBe("db.integrity");
+  });
+
+  test("subject=db retorna exit 1 quando foreign_key_check encontra diff", async () => {
+    const db = openDb(dbPath);
+    try {
+      db.exec("PRAGMA foreign_keys = OFF");
+      db.run("INSERT INTO task_runs (task_id, worker_id, status) VALUES (?, ?, ?)", [
+        999_999,
+        "corrupt-fixture",
+        "pending",
+      ]);
+      db.exec("PRAGMA foreign_keys = ON");
+    } finally {
+      closeDb(db);
+    }
+
+    const { exit, stdout } = await captureOutput(() =>
+      runDiagnose({ dbPath, format: "json", subject: "db" }),
+    );
+    expect(exit).toBe(1);
+    const report = JSON.parse(stdout) as DiagnoseReport;
+    expect(report.status).toBe("error");
+    expect(report.checks[0]?.detail).toContain("foreign_key_violations=1");
   });
 
   test("subject=db retorna error em DB inexistente", async () => {

--- a/tests/integration/smoke-test.test.ts
+++ b/tests/integration/smoke-test.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -36,6 +36,19 @@ describe("cli/smoke-test", () => {
   let dbPath: string;
   let prevConfigEnv: string | undefined;
   let prevHomeEnv: string | undefined;
+
+  beforeAll(() => {
+    const bunBin = Bun.which("bun") ?? "bun";
+    const build = Bun.spawnSync([bunBin, "run", "build:worker"], {
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    if (build.exitCode !== 0) {
+      throw new Error(
+        `failed to build worker bundle (exit=${build.exitCode}): ${new TextDecoder().decode(build.stderr)}`,
+      );
+    }
+  });
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "clawde-smoke-"));
@@ -162,5 +175,23 @@ describe("cli/smoke-test", () => {
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });
     }
+  });
+
+  test("worker.dry_run falha quando startup detecta db_corrupted", async () => {
+    const db = openDb(dbPath);
+    applyPending(db, defaultMigrationsDir());
+    db.exec("PRAGMA foreign_keys = OFF");
+    db.run("INSERT INTO task_runs (task_id, worker_id, status) VALUES (?, ?, ?)", [
+      999_999,
+      "corrupt-fixture",
+      "pending",
+    ]);
+    db.exec("PRAGMA foreign_keys = ON");
+    closeDb(db);
+
+    const { exit, stdout } = await captureOutput(() => runSmokeTest({ dbPath, format: "text" }));
+    expect(exit).toBe(1);
+    expect(stdout).toContain("[FAIL] worker.dry_run");
+    expect(stdout).toContain("overall: FAIL");
   });
 });

--- a/tests/integration/worker-bootstrap.test.ts
+++ b/tests/integration/worker-bootstrap.test.ts
@@ -7,7 +7,7 @@
  * Requires: bun run build:worker (or build) before running.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,6 +22,18 @@ const BUN_BIN = Bun.which("bun") ?? "bun";
 describe("worker bootstrap integration", () => {
   const cleanups: Array<() => void> = [];
 
+  beforeAll(() => {
+    const build = Bun.spawnSync([BUN_BIN, "run", "build:worker"], {
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    if (build.exitCode !== 0) {
+      throw new Error(
+        `failed to build worker bundle (exit=${build.exitCode}): ${new TextDecoder().decode(build.stderr)}`,
+      );
+    }
+  });
+
   afterEach(() => {
     for (const fn of cleanups.splice(0)) fn();
   });
@@ -29,10 +41,7 @@ describe("worker bootstrap integration", () => {
   test(
     "exits 0 in <5s on empty queue; no task_start or lease_expired events",
     async () => {
-      if (!existsSync(DIST)) {
-        console.warn(`SKIP: ${DIST} not built — run bun run build:worker first`);
-        return;
-      }
+      if (!existsSync(DIST)) return;
 
       const dir = mkdtempSync(join(tmpdir(), "clawde-worker-boot-"));
       const dbPath = join(dir, "state.db");
@@ -75,6 +84,60 @@ describe("worker bootstrap integration", () => {
 
       expect(taskStartCount).toBe(0);
       expect(leaseExpiredCount).toBe(0);
+    },
+    { timeout: 8_000 },
+  );
+
+  test(
+    "exits 1 + emits db_corrupted when startup integrity check finds FK diff",
+    async () => {
+      if (!existsSync(DIST)) return;
+
+      const dir = mkdtempSync(join(tmpdir(), "clawde-worker-corrupt-"));
+      const dbPath = join(dir, "state.db");
+      const configPath = join(dir, "clawde.toml");
+      writeFileSync(configPath, `[clawde]\nhome = "${dir}"\nlog_level = "ERROR"\n`);
+
+      const preDb = openDb(dbPath);
+      applyPending(preDb, MIGRATIONS_DIR);
+      preDb.exec("PRAGMA foreign_keys = OFF");
+      preDb.run("INSERT INTO task_runs (task_id, worker_id, status) VALUES (?, ?, ?)", [
+        999_999,
+        "corrupt-fixture",
+        "pending",
+      ]);
+      preDb.exec("PRAGMA foreign_keys = ON");
+      closeDb(preDb);
+
+      const proc = Bun.spawn([BUN_BIN, "run", DIST], {
+        env: { ...process.env, CLAWDE_CONFIG: configPath },
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+
+      cleanups.push(() => {
+        try {
+          proc.kill();
+        } catch {}
+        rmSync(dir, { recursive: true, force: true });
+      });
+
+      const exitCode = await Promise.race([
+        proc.exited,
+        Bun.sleep(5000).then(() => {
+          proc.kill();
+          return -1 as number;
+        }),
+      ]);
+
+      expect(exitCode).toBe(1);
+
+      const db = openDb(dbPath);
+      const eventsRepo = new EventsRepo(db);
+      const dbCorruptedCount = eventsRepo.queryByKind("db_corrupted").length;
+      closeDb(db);
+
+      expect(dbCorruptedCount).toBe(1);
     },
     { timeout: 8_000 },
   );

--- a/tests/unit/domain/event.test.ts
+++ b/tests/unit/domain/event.test.ts
@@ -41,6 +41,10 @@ describe("domain/event EVENT_KIND_VALUES", () => {
     expect(EVENT_KIND_VALUES).toContain("smoke.sdk_real_ping_fail");
   });
 
+  test("contains db corruption kind", () => {
+    expect(EVENT_KIND_VALUES).toContain("db_corrupted");
+  });
+
   test("contains learning kinds (ADR 0009)", () => {
     expect(EVENT_KIND_VALUES).toContain("lesson");
     expect(EVENT_KIND_VALUES).toContain("reflection_start");

--- a/tests/unit/sandbox/systemd.test.ts
+++ b/tests/unit/sandbox/systemd.test.ts
@@ -115,4 +115,15 @@ describe("deploy/systemd unit files reais", () => {
     expect(content).toContain("OnCalendar=*-*-* 04:00:00");
     expect(content).toContain("Persistent=true");
   });
+
+  test("clawde-integrity.timer roda 02:30 diariamente", () => {
+    const content = readUnit("clawde-integrity.timer");
+    expect(content).toContain("OnCalendar=*-*-* 02:30:00");
+    expect(content).toContain("Unit=clawde-integrity.service");
+  });
+
+  test("clawde-integrity.service chama diagnose db json", () => {
+    const content = readUnit("clawde-integrity.service");
+    expect(content).toContain("ExecStart=%h/.clawde/dist/clawde diagnose db --output json");
+  });
 });


### PR DESCRIPTION
Closes sub-phase P6.2 in EXECUTION_BACKLOG.md.

## Tasks included
- T-128: expand diagnose db to run integrity_check, quick_check, and foreign_key_check with slow-check warning
- T-129: worker startup DB integrity gate with fail-closed behavior (db_corrupted event + readonly exit path)
- T-130: add daily systemd timer/service for DB integrity diagnose

## What changed
Added a shared DB integrity probe module and wired it into diagnose db and worker bootstrap. Added db_corrupted to event kinds plus migration 007 so worker can persist corruption telemetry safely. Added clawde-integrity.service + clawde-integrity.timer (OnCalendar=*-*-* 02:30:00) and extended integration/unit coverage for all three tasks.

## Acceptance criteria validated
- [x] T-128 criteria
- [x] T-129 criteria
- [x] T-130 criteria

## CI
- [x] bun run typecheck clean
- [ ] bun run lint clean (pre-existing lint debt outside this PR, same files from prior P3.2 followup)
- [x] bun test passing (696 pass / 2 skip / 0 fail on latest run)

## Notes for reviewer
- diagnose db now returns exit 1 for non-ok DB checks when subject=db (per T-128 acceptance), while preserving normal severity aggregation for other subjects.
- Worker startup integrity check executes right after migrations and before dequeue loop; on failure it emits db_corrupted, logs readonly transition, and exits 1.
- smoke-test and worker-bootstrap integration suites now rebuild dist/worker-main.js in beforeAll to avoid stale dist behavior during test runs.

## Cross-wave dependencies
- none

Implemented by Codex