### PR TITLE
P6.3: events retention (export + purge + timer)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -55,7 +55,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | merged, PR #26, 2026-05-01 | #26 |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | merged, PR #29, 2026-05-01 | #29 |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | merged, PR #30, 2026-05-01 | #30 |
-| P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | pending | — |
+| P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | in-progress, codex | — |
 | P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | pending | — |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | pending | — |
 | P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | pending | — |
@@ -269,9 +269,9 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-130 — merged, PR #30, 2026-05-01
 
 ### P6.3 — Events retention
-- [ ] T-131 — pending
-- [ ] T-132 — pending — purge (security)
-- [ ] T-133 — pending
+- [ ] T-131 — in-progress, codex
+- [ ] T-132 — in-progress, codex — purge (security)
+- [ ] T-133 — in-progress, codex
 
 ### P6.4 — Alerts system
 - [ ] T-134 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -55,7 +55,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P3.6 | `task/P3.6-sdk-real-ci` | T-122..T-124 | codex | claude | merged, PR #26, 2026-05-01 | #26 |
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | merged, PR #29, 2026-05-01 | #29 |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | merged, PR #30, 2026-05-01 | #30 |
-| P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | in-progress, codex | — |
+| P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | in-review, PR #31 | #31 |
 | P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | pending | — |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | pending | — |
 | P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | pending | — |
@@ -269,9 +269,9 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-130 — merged, PR #30, 2026-05-01
 
 ### P6.3 — Events retention
-- [ ] T-131 — in-progress, codex
-- [ ] T-132 — in-progress, codex — purge (security)
-- [ ] T-133 — in-progress, codex
+- [ ] T-131 — in-review, codex, PR #31
+- [ ] T-132 — in-review, codex, PR #31 — purge (security)
+- [ ] T-133 — in-review, codex, PR #31
 
 ### P6.4 — Alerts system
 - [ ] T-134 — pending

--- a/deploy/systemd/clawde-events-retention.service
+++ b/deploy/systemd/clawde-events-retention.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Clawde events retention mensal (export + purge)
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/.clawde
+EnvironmentFile=-%h/.clawde/config/clawde.env
+ExecStart=/bin/bash -lc "%h/.clawde/dist/clawde events export --since-cutoff 90d && %h/.clawde/dist/clawde events purge --before $(date -d '90 days ago' -I) --confirm"
+
+# Hardening idêntico ao worker (BEST_PRACTICES §10.4)
+PrivateTmp=yes
+ProtectHome=read-only
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+ReadWritePaths=%h/.clawde /tmp
+
+[Install]
+WantedBy=default.target

--- a/deploy/systemd/clawde-events-retention.timer
+++ b/deploy/systemd/clawde-events-retention.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Clawde events retention agendado (mensal dia 1 às 04:00 local)
+
+[Timer]
+OnCalendar=*-*-01 04:00:00
+Unit=clawde-events-retention.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/src/cli/commands/events.ts
+++ b/src/cli/commands/events.ts
@@ -1,0 +1,193 @@
+/**
+ * `clawde events export|purge` — retenção de audit log (P6.3).
+ *
+ * export:
+ *   Lê events com ts mais antigo que o cutoff relativo (`--since-cutoff 90d`)
+ *   e grava JSONL em ~/.clawde/exports/events-YYYY-MM.jsonl.
+ *
+ * purge:
+ *   Remove events com ts anterior a uma data absoluta (`--before YYYY-MM-DD`)
+ *   usando _retention_grant para destravar trigger append-only.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { type ClawdeDatabase, closeDb, openDb } from "@clawde/db/client";
+import { type OutputFormat, emit, emitErr } from "../output.ts";
+
+export interface EventsOptionsBase {
+  readonly dbPath: string;
+  readonly format: OutputFormat;
+}
+
+export interface EventsExportOptions extends EventsOptionsBase {
+  readonly action: "export";
+  readonly sinceCutoff: string;
+}
+
+export interface EventsPurgeOptions extends EventsOptionsBase {
+  readonly action: "purge";
+  readonly before: string;
+  readonly confirm: boolean;
+}
+
+export type EventsAction = EventsExportOptions | EventsPurgeOptions;
+
+interface ExportRow {
+  id: number;
+  ts: string;
+  task_run_id: number | null;
+  session_id: string | null;
+  trace_id: string | null;
+  span_id: string | null;
+  kind: string;
+  payload: string;
+}
+
+function parseRelativeCutoffToSqlModifier(raw: string): string | null {
+  const match = raw.match(/^(\d+)([mhdw])$/);
+  if (match === null) return null;
+  const amount = Number.parseInt(match[1] ?? "0", 10);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  const unit = match[2];
+  if (unit === "m") return `-${amount} minutes`;
+  if (unit === "h") return `-${amount} hours`;
+  if (unit === "d") return `-${amount} days`;
+  return `-${amount * 7} days`;
+}
+
+function resolveDefaultExportsDir(dbPath: string): string {
+  const home = process.env.HOME;
+  if (home !== undefined && home.length > 0) {
+    return join(home, ".clawde", "exports");
+  }
+  return join(dirname(dbPath), "exports");
+}
+
+function monthStamp(now = new Date()): string {
+  return now.toISOString().slice(0, 7);
+}
+
+function runEventsExport(options: EventsExportOptions): number {
+  const cutoffModifier = parseRelativeCutoffToSqlModifier(options.sinceCutoff);
+  if (cutoffModifier === null) {
+    emitErr(`invalid --since-cutoff '${options.sinceCutoff}' (expected like 90d, 12h, 30m, 2w)`);
+    return 1;
+  }
+
+  let db: ClawdeDatabase;
+  try {
+    db = openDb(options.dbPath);
+  } catch (err) {
+    emitErr(`error opening db: ${(err as Error).message}`);
+    return 2;
+  }
+
+  try {
+    const rows = db
+      .query<ExportRow, [string]>(
+        `SELECT id, ts, task_run_id, session_id, trace_id, span_id, kind, payload
+           FROM events
+          WHERE ts < datetime('now', ?)
+          ORDER BY ts, id`,
+      )
+      .all(cutoffModifier);
+
+    const outputDir = resolveDefaultExportsDir(options.dbPath);
+    mkdirSync(outputDir, { recursive: true });
+    const outputPath = join(outputDir, `events-${monthStamp()}.jsonl`);
+
+    const lines = rows.map((row) => {
+      let payload: unknown;
+      try {
+        payload = JSON.parse(row.payload);
+      } catch {
+        payload = { parse_error: true, raw: row.payload };
+      }
+      return JSON.stringify({
+        id: row.id,
+        ts: row.ts,
+        taskRunId: row.task_run_id,
+        sessionId: row.session_id,
+        traceId: row.trace_id,
+        spanId: row.span_id,
+        kind: row.kind,
+        payload,
+      });
+    });
+    const fileBody = lines.length > 0 ? `${lines.join("\n")}\n` : "";
+    writeFileSync(outputPath, fileBody, "utf-8");
+
+    emit(
+      options.format,
+      { outputPath, exported: rows.length, sinceCutoff: options.sinceCutoff },
+      (d) => {
+        const data = d as { outputPath: string; exported: number; sinceCutoff: string };
+        return `exported ${data.exported} events (< now-${data.sinceCutoff}) to ${data.outputPath}`;
+      },
+    );
+    return 0;
+  } catch (err) {
+    emitErr(`error exporting events: ${(err as Error).message}`);
+    return 2;
+  } finally {
+    closeDb(db);
+  }
+}
+
+function isIsoDate(raw: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return false;
+  const d = new Date(`${raw}T00:00:00Z`);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === raw;
+}
+
+function runEventsPurge(options: EventsPurgeOptions): number {
+  if (!options.confirm) {
+    emitErr("error: --confirm required for destructive purge");
+    return 1;
+  }
+  if (!isIsoDate(options.before)) {
+    emitErr(`error: invalid --before '${options.before}' (expected YYYY-MM-DD)`);
+    return 1;
+  }
+
+  let db: ClawdeDatabase;
+  try {
+    db = openDb(options.dbPath);
+  } catch (err) {
+    emitErr(`error opening db: ${(err as Error).message}`);
+    return 2;
+  }
+
+  try {
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      db.exec("INSERT INTO _retention_grant DEFAULT VALUES");
+      db.run("DELETE FROM events WHERE ts < datetime(?, 'start of day')", [options.before]);
+      const deleted = (
+        db.query<{ n: number }, []>("SELECT changes() AS n").get() as { n: number } | null
+      )?.n;
+      db.exec("DELETE FROM _retention_grant");
+      db.exec("COMMIT");
+
+      emit(options.format, { before: options.before, deleted: deleted ?? 0 }, (d) => {
+        const data = d as { before: string; deleted: number };
+        return `purged ${data.deleted} events before ${data.before}`;
+      });
+      return 0;
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+  } catch (err) {
+    emitErr(`error purging events: ${(err as Error).message}`);
+    return 2;
+  } finally {
+    closeDb(db);
+  }
+}
+
+export function runEvents(action: EventsAction): number {
+  if (action.action === "export") return runEventsExport(action);
+  return runEventsPurge(action);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -15,6 +15,7 @@ import { runAuth } from "./commands/auth.ts";
 import { runConfigShow, runConfigValidate } from "./commands/config.ts";
 import { runDashboard } from "./commands/dashboard.ts";
 import { DIAGNOSE_SUBJECTS, type DiagnoseSubject, runDiagnose } from "./commands/diagnose.ts";
+import { runEvents } from "./commands/events.ts";
 import { runLogs } from "./commands/logs.ts";
 import { runMemory } from "./commands/memory.ts";
 import { runMigrate } from "./commands/migrate.ts";
@@ -115,6 +116,7 @@ Commands:
   panic-resume           Destrava após panic-stop (requer diagnose all=ok)
   sessions <list|show <id>>  Inspeciona sessões persistentes do SDK
   config <show|validate <path>>  Dump/valida config TOML resolvida
+  events <export|purge>      Exporta/purge events antigos (retenção)
   reflect [--since 24h]   Enfileira reflection job (events+observations recentes)
   version                Mostra semver
   help                   Esta mensagem
@@ -131,6 +133,10 @@ Migrate options:
   --audit-sandbox        Em migrate status, audita agentes com network="allowlist"
   --fail-on-allowlist    Com --audit-sandbox, retorna exit 2 se houver achados
   --agents-root <path>   Root dos agentes (default .claude/agents)
+
+Events options:
+  export --since-cutoff 90d
+  purge --before YYYY-MM-DD --confirm
 `;
 
 export async function runMain(argv: ReadonlyArray<string>): Promise<number> {
@@ -280,6 +286,39 @@ export async function runMain(argv: ReadonlyArray<string>): Promise<number> {
       return runMigrate({ action: "down", ...migrateCommon, target, confirm });
     }
     emitErr(`unknown migrate action: ${action}`);
+    return 1;
+  }
+
+  if (parsed.command === "events") {
+    const action = parsed.positional[0];
+    if (action === "export") {
+      const sinceCutoff = getFlag(parsed, "since-cutoff");
+      if (sinceCutoff === undefined || sinceCutoff.length === 0) {
+        emitErr("error: events export requires --since-cutoff <duration>");
+        return 1;
+      }
+      return runEvents({
+        action: "export",
+        dbPath: getDbPath(parsed),
+        format: getOutputFormat(parsed),
+        sinceCutoff,
+      });
+    }
+    if (action === "purge") {
+      const before = getFlag(parsed, "before");
+      if (before === undefined || before.length === 0) {
+        emitErr("error: events purge requires --before YYYY-MM-DD");
+        return 1;
+      }
+      return runEvents({
+        action: "purge",
+        dbPath: getDbPath(parsed),
+        format: getOutputFormat(parsed),
+        before,
+        confirm: parsed.flags.confirm === true,
+      });
+    }
+    emitErr("unknown events action: use export|purge");
     return 1;
   }
 

--- a/tests/integration/events-cmd.test.ts
+++ b/tests/integration/events-cmd.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runEvents } from "@clawde/cli/commands/events";
+import { closeDb, openDb } from "@clawde/db/client";
+import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
+
+function captureOutput(fn: () => number): { exit: number; stdout: string; stderr: string } {
+  const origStdoutWrite = process.stdout.write.bind(process.stdout);
+  const origStderrWrite = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+  process.stdout.write = ((chunk: unknown): boolean => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown): boolean => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const exit = fn();
+    return { exit, stdout, stderr };
+  } finally {
+    process.stdout.write = origStdoutWrite;
+    process.stderr.write = origStderrWrite;
+  }
+}
+
+describe("cli/commands/events", () => {
+  let dir: string;
+  let dbPath: string;
+  let prevHomeEnv: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "clawde-events-"));
+    dbPath = join(dir, "state.db");
+    prevHomeEnv = process.env.HOME;
+    process.env.HOME = dir;
+
+    const db = openDb(dbPath);
+    try {
+      applyPending(db, defaultMigrationsDir());
+      db.exec(`
+        INSERT INTO events (ts, kind, payload)
+        VALUES
+          ('2020-01-10T00:00:00Z', 'enqueue', '{"old":true}'),
+          ('2020-02-10T00:00:00Z', 'task_start', '{"old":true}'),
+          ('2099-01-01T00:00:00Z', 'task_finish', '{"future":true}')
+      `);
+    } finally {
+      closeDb(db);
+    }
+  });
+
+  afterEach(() => {
+    if (prevHomeEnv !== undefined) {
+      process.env.HOME = prevHomeEnv;
+    } else {
+      process.env.HOME = undefined;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("export grava JSONL com rows antigas do cutoff", () => {
+    const out = captureOutput(() =>
+      runEvents({
+        action: "export",
+        dbPath,
+        format: "json",
+        sinceCutoff: "90d",
+      }),
+    );
+    expect(out.exit).toBe(0);
+
+    const parsed = JSON.parse(out.stdout) as {
+      outputPath: string;
+      exported: number;
+      sinceCutoff: string;
+    };
+    expect(parsed.sinceCutoff).toBe("90d");
+    expect(parsed.exported).toBe(2);
+    expect(existsSync(parsed.outputPath)).toBe(true);
+
+    const lines = readFileSync(parsed.outputPath, "utf-8")
+      .trim()
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as { kind: string; payload: Record<string, unknown> });
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.kind).toBe("enqueue");
+    expect(lines[1]?.kind).toBe("task_start");
+    expect(lines[0]?.payload.old).toBe(true);
+  });
+
+  test("purge exige --confirm", () => {
+    const out = captureOutput(() =>
+      runEvents({
+        action: "purge",
+        dbPath,
+        format: "text",
+        before: "2020-02-01",
+        confirm: false,
+      }),
+    );
+    expect(out.exit).toBe(1);
+    expect(out.stderr).toContain("--confirm required");
+  });
+
+  test("purge remove rows anteriores à data e limpa retention grant", () => {
+    const out = captureOutput(() =>
+      runEvents({
+        action: "purge",
+        dbPath,
+        format: "json",
+        before: "2020-02-01",
+        confirm: true,
+      }),
+    );
+    expect(out.exit).toBe(0);
+    const parsed = JSON.parse(out.stdout) as { before: string; deleted: number };
+    expect(parsed.before).toBe("2020-02-01");
+    expect(parsed.deleted).toBe(1);
+
+    const db = openDb(dbPath);
+    try {
+      const count = (
+        db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM events").get() as { n: number }
+      ).n;
+      expect(count).toBe(2);
+      const grantCount = (
+        db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM _retention_grant").get() as {
+          n: number;
+        }
+      ).n;
+      expect(grantCount).toBe(0);
+    } finally {
+      closeDb(db);
+    }
+  });
+
+  test("purge é idempotente (segunda execução deleta 0)", () => {
+    const first = captureOutput(() =>
+      runEvents({
+        action: "purge",
+        dbPath,
+        format: "json",
+        before: "2020-02-01",
+        confirm: true,
+      }),
+    );
+    expect(first.exit).toBe(0);
+
+    const second = captureOutput(() =>
+      runEvents({
+        action: "purge",
+        dbPath,
+        format: "json",
+        before: "2020-02-01",
+        confirm: true,
+      }),
+    );
+    expect(second.exit).toBe(0);
+    const parsed = JSON.parse(second.stdout) as { deleted: number };
+    expect(parsed.deleted).toBe(0);
+  });
+});

--- a/tests/unit/sandbox/systemd.test.ts
+++ b/tests/unit/sandbox/systemd.test.ts
@@ -126,4 +126,16 @@ describe("deploy/systemd unit files reais", () => {
     const content = readUnit("clawde-integrity.service");
     expect(content).toContain("ExecStart=%h/.clawde/dist/clawde diagnose db --output json");
   });
+
+  test("clawde-events-retention.timer roda mensal dia 1 às 04:00", () => {
+    const content = readUnit("clawde-events-retention.timer");
+    expect(content).toContain("OnCalendar=*-*-01 04:00:00");
+    expect(content).toContain("Unit=clawde-events-retention.service");
+  });
+
+  test("clawde-events-retention.service exporta e purga com abort em falha", () => {
+    const content = readUnit("clawde-events-retention.service");
+    expect(content).toContain("clawde events export --since-cutoff 90d &&");
+    expect(content).toContain("clawde events purge --before $(date -d '90 days ago' -I) --confirm");
+  });
 });


### PR DESCRIPTION
Closes sub-phase P6.3 in EXECUTION_BACKLOG.md.

## Tasks included
- T-131: `clawde events export --since-cutoff 90d` (JSONL export em `~/.clawde/exports/events-YYYY-MM.jsonl`)
- T-132: `clawde events purge --before YYYY-MM-DD --confirm` usando `_retention_grant`
- T-133: unit files systemd mensais para export + purge

## What changed
- Novo comando `events` no CLI com ações `export` e `purge`.
- Export lê eventos com `ts < datetime('now', cutoff)` e grava JSONL em arquivo mensal.
- Purge exige `--confirm`, valida data ISO, abre grant temporário de retenção, deleta e limpa grant em transação.
- Adicionados `deploy/systemd/clawde-events-retention.service` e `.timer` com execução mensal (dia 1, 04:00).

## Acceptance criteria validated
- [x] T-131 criteria
- [x] T-132 criteria
- [x] T-133 criteria

## CI
- [x] `bun run typecheck` clean
- [ ] `bun run lint` clean (debt pré-existente fora desta PR, já conhecido desde P3.2)
- [x] `bun test` passing (702 pass / 2 skip / 0 fail)

## Notes for reviewer
- T-131/T-132 foram implementadas no mesmo commit por compartilharem parsing/roteamento e o mesmo módulo `events.ts`.
- `purge` é idempotente (segunda execução retorna `deleted: 0`) e o teste valida que `_retention_grant` fica limpo.
- Service de retenção usa `&&` para abortar purge se export falhar, conforme spec.

## Cross-wave dependencies
- none

Implemented by Codex
