### PR TITLE
P6.4: alerts system

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -56,7 +56,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | merged, PR #29, 2026-05-01 | #29 |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | merged, PR #30, 2026-05-01 | #30 |
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | merged, PR #31, 2026-05-01 | #31 |
-| P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | pending | — |
+| P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | in-progress, codex | — |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | pending | — |
 | P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | pending | — |
 
@@ -274,10 +274,10 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-133 — merged, PR #31, 2026-05-01
 
 ### P6.4 — Alerts system
-- [ ] T-134 — pending
-- [ ] T-135 — pending
-- [ ] T-136 — pending
-- [ ] T-137 — pending
+- [ ] T-134 — in-progress, codex
+- [ ] T-135 — in-progress, codex
+- [ ] T-136 — in-progress, codex
+- [ ] T-137 — in-progress, codex
 
 ### P6.5 — Backup cadenciado
 - [ ] T-138 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -56,7 +56,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | merged, PR #29, 2026-05-01 | #29 |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | merged, PR #30, 2026-05-01 | #30 |
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | merged, PR #31, 2026-05-01 | #31 |
-| P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | in-review, codex | — |
+| P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | in-review, PR #32 | #32 |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | pending | — |
 | P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | pending | — |
 
@@ -274,10 +274,10 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-133 — merged, PR #31, 2026-05-01
 
 ### P6.4 — Alerts system
-- [x] T-134 — in-review, codex
-- [x] T-135 — in-review, codex
-- [x] T-136 — in-review, codex
-- [x] T-137 — in-review, codex
+- [x] T-134 — in-review, PR #32
+- [x] T-135 — in-review, PR #32
+- [x] T-136 — in-review, PR #32
+- [x] T-137 — in-review, PR #32
 
 ### P6.5 — Backup cadenciado
 - [ ] T-138 — pending

--- a/STATUS.md
+++ b/STATUS.md
@@ -56,7 +56,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P6.1 | `task/P6.1-ci-security-gates` | T-125..T-127 | codex | claude (+ operador em T-125) | merged, PR #29, 2026-05-01 | #29 |
 | P6.2 | `task/P6.2-db-integrity` | T-128..T-130 | codex | claude | merged, PR #30, 2026-05-01 | #30 |
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | merged, PR #31, 2026-05-01 | #31 |
-| P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | in-progress, codex | — |
+| P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | in-review, codex | — |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | pending | — |
 | P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | pending | — |
 
@@ -274,10 +274,10 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-133 — merged, PR #31, 2026-05-01
 
 ### P6.4 — Alerts system
-- [ ] T-134 — in-progress, codex
-- [ ] T-135 — in-progress, codex
-- [ ] T-136 — in-progress, codex
-- [ ] T-137 — in-progress, codex
+- [x] T-134 — in-review, codex
+- [x] T-135 — in-review, codex
+- [x] T-136 — in-review, codex
+- [x] T-137 — in-review, codex
 
 ### P6.5 — Backup cadenciado
 - [ ] T-138 — pending

--- a/src/alerts/email.ts
+++ b/src/alerts/email.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from "node:fs";
+import { type Socket, connect as netConnect } from "node:net";
+import { join } from "node:path";
+import { connect as tlsConnect } from "node:tls";
+import type { ClawdeConfig } from "@clawde/config/schema";
+import type { Alert, AlertChannel } from "./types.ts";
+
+function readCredential(name: string, env: Record<string, string | undefined>): string | null {
+  const credDir = env.CREDENTIALS_DIRECTORY;
+  if (credDir !== undefined && credDir.length > 0) {
+    try {
+      const v = readFileSync(join(credDir, name), "utf-8").trim();
+      if (v.length > 0) return v;
+    } catch {
+      // fallback pro env
+    }
+  }
+  const candidates = [name, name.toUpperCase().replace(/[^A-Z0-9]/g, "_")];
+  for (const key of candidates) {
+    const v = env[key];
+    if (v !== undefined && v.length > 0) return v;
+  }
+  return null;
+}
+
+function renderSubject(alert: Alert): string {
+  return `[clawde][${alert.severity.toUpperCase()}] ${alert.trigger}`;
+}
+
+function renderBody(alert: Alert): string {
+  return [
+    `severity: ${alert.severity}`,
+    `trigger: ${alert.trigger}`,
+    `cooldown_key: ${alert.cooldownKey}`,
+    "",
+    JSON.stringify(alert.payload, null, 2),
+    "",
+  ].join("\n");
+}
+
+async function readSmtpResponse(socket: Socket): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    let buf = "";
+    const onData = (chunk: Buffer): void => {
+      buf += chunk.toString("utf-8");
+      if (buf.includes("\r\n")) {
+        cleanup();
+        resolve(buf);
+      }
+    };
+    const onErr = (err: Error): void => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = (): void => {
+      socket.off("data", onData);
+      socket.off("error", onErr);
+    };
+    socket.on("data", onData);
+    socket.on("error", onErr);
+  });
+}
+
+async function smtpCommand(socket: Socket, command: string, expectPrefix: string): Promise<void> {
+  socket.write(`${command}\r\n`);
+  const line = await readSmtpResponse(socket);
+  if (!line.startsWith(expectPrefix)) {
+    throw new Error(`SMTP expected ${expectPrefix} for '${command}', got: ${line.trim()}`);
+  }
+}
+
+async function upgradeToStartTls(socket: Socket, host: string): Promise<Socket> {
+  return await new Promise((resolve, reject) => {
+    const tls = tlsConnect({ socket, servername: host }, () => resolve(tls));
+    tls.once("error", reject);
+  });
+}
+
+export interface EmailAlertConfig {
+  readonly host: string;
+  readonly port: number;
+  readonly username: string;
+  readonly password: string;
+  readonly from: string;
+  readonly to: string;
+}
+
+export class EmailAlertChannel implements AlertChannel {
+  constructor(
+    private readonly cfg: EmailAlertConfig,
+    private readonly connectImpl: typeof netConnect = netConnect,
+  ) {}
+
+  async send(alert: Alert): Promise<void> {
+    const socket = this.connectImpl(this.cfg.port, this.cfg.host);
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", () => resolve());
+      socket.once("error", reject);
+    });
+    try {
+      const greeting = await readSmtpResponse(socket);
+      if (!greeting.startsWith("220")) {
+        throw new Error(`SMTP greeting invalid: ${greeting.trim()}`);
+      }
+
+      await smtpCommand(socket, "EHLO clawde", "250");
+      await smtpCommand(socket, "STARTTLS", "220");
+      const tlsSocket = await upgradeToStartTls(socket, this.cfg.host);
+      await smtpCommand(tlsSocket, "EHLO clawde", "250");
+      await smtpCommand(tlsSocket, "AUTH LOGIN", "334");
+      await smtpCommand(tlsSocket, Buffer.from(this.cfg.username).toString("base64"), "334");
+      await smtpCommand(tlsSocket, Buffer.from(this.cfg.password).toString("base64"), "235");
+
+      await smtpCommand(tlsSocket, `MAIL FROM:<${this.cfg.from}>`, "250");
+      await smtpCommand(tlsSocket, `RCPT TO:<${this.cfg.to}>`, "250");
+      await smtpCommand(tlsSocket, "DATA", "354");
+
+      const body = renderBody(alert).replace(/\n/g, "\r\n");
+      const data = [
+        `From: ${this.cfg.from}`,
+        `To: ${this.cfg.to}`,
+        `Subject: ${renderSubject(alert)}`,
+        "MIME-Version: 1.0",
+        'Content-Type: multipart/alternative; boundary="clawde-boundary"',
+        "",
+        "--clawde-boundary",
+        'Content-Type: text/plain; charset="utf-8"',
+        "",
+        body,
+        "--clawde-boundary--",
+        ".",
+      ].join("\r\n");
+      tlsSocket.write(`${data}\r\n`);
+      const accepted = await readSmtpResponse(tlsSocket);
+      if (!accepted.startsWith("250")) {
+        throw new Error(`SMTP DATA failed: ${accepted.trim()}`);
+      }
+      await smtpCommand(tlsSocket, "QUIT", "221");
+      tlsSocket.end();
+    } catch (err) {
+      socket.destroy();
+      throw err;
+    }
+  }
+}
+
+export function createEmailAlertChannelFromConfig(
+  config: ClawdeConfig,
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): AlertChannel | null {
+  const c = config.alerts?.email;
+  if (c === undefined) return null;
+  const username = readCredential(c.smtp_username_credential, env);
+  const password = readCredential(c.smtp_password_credential, env);
+  if (username === null || password === null) return null;
+  return new EmailAlertChannel({
+    host: c.smtp_host,
+    port: c.smtp_port,
+    username,
+    password,
+    from: c.from,
+    to: c.to,
+  });
+}

--- a/src/alerts/index.ts
+++ b/src/alerts/index.ts
@@ -1,0 +1,135 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { loadConfig } from "@clawde/config";
+import { createEmailAlertChannelFromConfig } from "./email.ts";
+import { createTelegramAlertChannelFromConfig } from "./telegram.ts";
+import type { Alert, AlertChannel, DispatchResult } from "./types.ts";
+
+export type { Alert, AlertChannel, AlertSeverity, DispatchResult } from "./types.ts";
+
+const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000;
+
+export interface DispatcherOptions {
+  readonly stateDir?: string;
+  readonly defaultCooldownMs?: number;
+  readonly now?: () => Date;
+}
+
+function expandHome(path: string): string {
+  if (path === "~" || path.startsWith("~/")) {
+    return path.replace(/^~/, homedir());
+  }
+  return path;
+}
+
+function resolveStateDir(
+  stateDir: string | undefined,
+  env: Record<string, string | undefined>,
+): string {
+  if (stateDir !== undefined && stateDir.length > 0) return stateDir;
+  const home = env.CLAWDE_HOME;
+  if (home !== undefined && home.length > 0) {
+    return join(expandHome(home), "state", "alerts");
+  }
+  return join(homedir(), ".clawde", "state", "alerts");
+}
+
+function lockFilePath(stateDir: string, cooldownKey: string): string {
+  const safe = cooldownKey.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return join(stateDir, `${safe}.lock`);
+}
+
+function withinCooldown(path: string, nowMs: number, cooldownMs: number): boolean {
+  if (!existsSync(path)) return false;
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    const ts = Number.parseInt(raw, 10);
+    if (!Number.isFinite(ts)) return false;
+    return nowMs - ts < cooldownMs;
+  } catch {
+    return false;
+  }
+}
+
+function markSent(path: string, nowMs: number): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, String(nowMs), "utf-8");
+}
+
+export async function dispatchAlert(
+  alert: Alert,
+  channels: ReadonlyArray<AlertChannel>,
+  options: DispatcherOptions = {},
+): Promise<DispatchResult> {
+  if (channels.length === 0) {
+    return { sent: false, skippedByCooldown: false, channelErrors: [] };
+  }
+
+  const env = process.env as Record<string, string | undefined>;
+  const stateDir = resolveStateDir(options.stateDir, env);
+  mkdirSync(stateDir, { recursive: true });
+
+  const now = options.now ?? (() => new Date());
+  const nowMs = now().getTime();
+  const cooldownMs = alert.cooldownMs ?? options.defaultCooldownMs ?? DEFAULT_COOLDOWN_MS;
+  const lockPath = lockFilePath(stateDir, alert.cooldownKey);
+  if (withinCooldown(lockPath, nowMs, cooldownMs)) {
+    return { sent: false, skippedByCooldown: true, channelErrors: [] };
+  }
+
+  const errors: string[] = [];
+  let sentCount = 0;
+  for (const channel of channels) {
+    try {
+      await channel.send(alert);
+      sentCount += 1;
+    } catch (err) {
+      errors.push((err as Error).message);
+    }
+  }
+  if (sentCount > 0) {
+    markSent(lockPath, nowMs);
+  }
+  return {
+    sent: sentCount > 0,
+    skippedByCooldown: false,
+    channelErrors: errors,
+  };
+}
+
+let cachedChannels: ReadonlyArray<AlertChannel> | null = null;
+let cachedStateDir: string | null = null;
+
+function defaultChannelsFromConfig(): ReadonlyArray<AlertChannel> {
+  if (cachedChannels !== null) return cachedChannels;
+  try {
+    const config = loadConfig();
+    cachedChannels = [
+      createTelegramAlertChannelFromConfig(config),
+      createEmailAlertChannelFromConfig(config),
+    ].filter((c): c is AlertChannel => c !== null);
+    cachedStateDir = join(expandHome(config.clawde.home), "state", "alerts");
+    return cachedChannels;
+  } catch {
+    cachedChannels = [];
+    cachedStateDir = null;
+    return cachedChannels;
+  }
+}
+
+export function resetAlertRuntimeForTests(): void {
+  cachedChannels = null;
+  cachedStateDir = null;
+}
+
+export async function sendAlertBestEffort(alert: Alert): Promise<void> {
+  try {
+    const channels = defaultChannelsFromConfig();
+    await dispatchAlert(alert, channels, {
+      ...(cachedStateDir !== null ? { stateDir: cachedStateDir } : {}),
+    });
+  } catch {
+    // Alerting não pode derrubar fluxo principal.
+  }
+}

--- a/src/alerts/telegram.ts
+++ b/src/alerts/telegram.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ClawdeConfig } from "@clawde/config/schema";
+import type { Alert, AlertChannel } from "./types.ts";
+
+function readCredential(name: string, env: Record<string, string | undefined>): string | null {
+  const credDir = env.CREDENTIALS_DIRECTORY;
+  if (credDir !== undefined && credDir.length > 0) {
+    try {
+      const v = readFileSync(join(credDir, name), "utf-8").trim();
+      if (v.length > 0) return v;
+    } catch {
+      // fallback pro env
+    }
+  }
+  const candidates = [name, name.toUpperCase().replace(/[^A-Z0-9]/g, "_")];
+  for (const key of candidates) {
+    const v = env[key];
+    if (v !== undefined && v.length > 0) return v;
+  }
+  return null;
+}
+
+function renderMessage(alert: Alert): string {
+  return `[${alert.severity.toUpperCase()}][${alert.trigger}] ${JSON.stringify(alert.payload)}`;
+}
+
+export class TelegramAlertChannel implements AlertChannel {
+  constructor(
+    private readonly token: string,
+    private readonly chatId: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async send(alert: Alert): Promise<void> {
+    const url = `https://api.telegram.org/bot${this.token}/sendMessage`;
+    const response = await this.fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: this.chatId,
+        text: renderMessage(alert),
+        disable_web_page_preview: true,
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`telegram alert failed: HTTP ${response.status} ${body}`);
+    }
+  }
+}
+
+export function createTelegramAlertChannelFromConfig(
+  config: ClawdeConfig,
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): AlertChannel | null {
+  const tg = config.telegram;
+  if (tg === undefined) return null;
+  const tokenCredential = tg.bot_token_credential;
+  const chatCredential = tg.alert_chat_id_credential;
+  if (tokenCredential === undefined || chatCredential === undefined) return null;
+
+  const token = readCredential(tokenCredential, env);
+  const chatId = readCredential(chatCredential, env);
+  if (token === null || chatId === null) return null;
+  return new TelegramAlertChannel(token, chatId);
+}

--- a/src/alerts/types.ts
+++ b/src/alerts/types.ts
@@ -1,0 +1,20 @@
+export type AlertSeverity = "critical" | "high" | "medium" | "low";
+
+export interface Alert {
+  readonly severity: AlertSeverity;
+  readonly trigger: string;
+  readonly payload: Readonly<Record<string, unknown>>;
+  readonly cooldownKey: string;
+  /** Cooldown opcional por alerta; default do dispatcher = 1h. */
+  readonly cooldownMs?: number;
+}
+
+export interface AlertChannel {
+  send(alert: Alert): Promise<void>;
+}
+
+export interface DispatchResult {
+  readonly sent: boolean;
+  readonly skippedByCooldown: boolean;
+  readonly channelErrors: ReadonlyArray<string>;
+}

--- a/src/cli/commands/smoke-test.ts
+++ b/src/cli/commands/smoke-test.ts
@@ -12,6 +12,7 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { AgentDefinitionError, loadAllAgentDefinitions } from "@clawde/agents";
+import { sendAlertBestEffort } from "@clawde/alerts";
 import { OAuthLoadError, getTokenExpiry, loadOAuthToken } from "@clawde/auth";
 import { type ClawdeDatabase, closeDb, openDb } from "@clawde/db/client";
 import { defaultMigrationsDir, status } from "@clawde/db/migrations";
@@ -212,6 +213,13 @@ function checkOAuthExpiry(): CheckResult {
       };
     }
     if (days < 30) {
+      void sendAlertBestEffort({
+        severity: "medium",
+        trigger: "oauth_expiry_warning",
+        cooldownKey: "oauth_expiry_warning",
+        cooldownMs: 24 * 60 * 60 * 1000,
+        payload: { days_until_expiry: days },
+      });
       return {
         name: "auth.oauth_expiry",
         ok: true,
@@ -306,6 +314,17 @@ export async function runSmokeTest(options: SmokeTestOptions): Promise<number> {
 
   const allOk = checks.every((c) => c.ok);
   const report: SmokeReport = { ok: allOk, checks };
+
+  if (!allOk) {
+    void sendAlertBestEffort({
+      severity: "high",
+      trigger: "smoke_test_fail",
+      cooldownKey: "smoke_test_fail",
+      payload: {
+        failed_checks: checks.filter((c) => !c.ok).map((c) => c.name),
+      },
+    });
+  }
 
   if (sdkPing.eventKind !== undefined) {
     try {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -84,6 +84,8 @@ export const TelegramConfigSchema = z.object({
   allowed_user_ids: z.array(z.number().int().positive()).default([]),
   default_priority: z.enum(["LOW", "NORMAL", "HIGH", "URGENT"]).default("NORMAL"),
   default_agent: z.string().default("telegram-bot"),
+  bot_token_credential: z.string().default("clawde-telegram-bot-token"),
+  alert_chat_id_credential: z.string().default("clawde-telegram-alert-chat-id"),
 });
 
 export const ReviewConfigSchema = z.object({
@@ -97,6 +99,19 @@ export const ReplicaConfigSchema = z.object({
   max_age_minutes: z.number().int().positive().default(90),
 });
 
+export const AlertsEmailConfigSchema = z.object({
+  smtp_host: z.string().min(1),
+  smtp_port: z.number().int().positive().default(587),
+  smtp_username_credential: z.string().min(1),
+  smtp_password_credential: z.string().min(1),
+  from: z.string().default("clawde@localhost"),
+  to: z.string().default("root@localhost"),
+});
+
+export const AlertsConfigSchema = z.object({
+  email: AlertsEmailConfigSchema.optional(),
+});
+
 export const ClawdeConfigSchema = z.object({
   clawde: ClawdeBaseSchema.default(() => ClawdeBaseSchema.parse({})),
   worker: WorkerSchema.default(() => WorkerSchema.parse({})),
@@ -108,6 +123,7 @@ export const ClawdeConfigSchema = z.object({
   telegram: TelegramConfigSchema.optional(),
   review: ReviewConfigSchema.optional(),
   replica: ReplicaConfigSchema.optional(),
+  alerts: AlertsConfigSchema.optional(),
 });
 
 export type ClawdeConfig = z.infer<typeof ClawdeConfigSchema>;

--- a/src/db/migrations/runner.ts
+++ b/src/db/migrations/runner.ts
@@ -8,6 +8,7 @@
 
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { sendAlertBestEffort } from "@clawde/alerts";
 import type { ClawdeDatabase } from "../client.ts";
 
 export interface MigrationFile {
@@ -153,6 +154,16 @@ export function applyPending(db: ClawdeDatabase, dir: string): ReadonlyArray<num
       db.exec("COMMIT");
     } catch (err) {
       db.exec("ROLLBACK");
+      void sendAlertBestEffort({
+        severity: "critical",
+        trigger: "migration_fail",
+        cooldownKey: `migration_fail_${m.version}`,
+        payload: {
+          version: m.version,
+          slug: m.slug,
+          error: (err as Error).message,
+        },
+      });
       throw new Error(`migration ${m.version} (${m.slug}) failed: ${(err as Error).message}`);
     }
     newlyApplied.push(m.version);
@@ -196,6 +207,16 @@ export function rollbackTo(
       db.exec("COMMIT");
     } catch (err) {
       db.exec("ROLLBACK");
+      void sendAlertBestEffort({
+        severity: "critical",
+        trigger: "migration_fail",
+        cooldownKey: `migration_rollback_fail_${v}`,
+        payload: {
+          version: v,
+          slug: m.slug,
+          error: (err as Error).message,
+        },
+      });
       throw new Error(`rollback ${v} (${m.slug}) failed: ${(err as Error).message}`);
     }
     reverted.push(v);

--- a/src/log/logger.ts
+++ b/src/log/logger.ts
@@ -7,6 +7,7 @@
  * Payload é redacted antes de serializar.
  */
 
+import { sendAlertBestEffort } from "@clawde/alerts";
 import { redact } from "./redact.ts";
 import { getTraceContext } from "./trace.ts";
 
@@ -105,6 +106,20 @@ export function createLogger(ctx: LoggerContext = {}): Logger {
     // baseCtx pode conter secrets também; redact aplicado no entry inteiro.
     const safe = redact(entry) as LogEntry;
     activeSink(JSON.stringify(safe));
+
+    if (level === "FATAL") {
+      queueMicrotask(() => {
+        void sendAlertBestEffort({
+          severity: "critical",
+          trigger: "fatal_log",
+          cooldownKey: "fatal_log",
+          payload: {
+            msg,
+            ...(fields !== undefined ? (redact(fields) as Record<string, unknown>) : {}),
+          },
+        });
+      });
+    }
   }
 
   return {

--- a/src/quota/policy.ts
+++ b/src/quota/policy.ts
@@ -13,6 +13,7 @@
  * `restrito`/`critico` (default 15%, configurável).
  */
 
+import { sendAlertBestEffort } from "@clawde/alerts";
 import type {
   Plan,
   QuotaDecision,
@@ -66,6 +67,21 @@ export function makeQuotaPolicy(_config: PolicyConfig = DEFAULT_POLICY_CONFIG): 
   // Config aceito para extensibilidade futura (custom thresholds/reserve).
   return {
     canAccept(window: QuotaWindow, priority: Priority): QuotaDecision {
+      if (window.state === "critico") {
+        void sendAlertBestEffort({
+          severity: "high",
+          trigger: "quota_critical",
+          cooldownKey: `quota_critical_${window.plan}`,
+          cooldownMs: 60 * 60 * 1000,
+          payload: {
+            plan: window.plan,
+            state: window.state,
+            msgs_consumed: window.msgsConsumed,
+            window_start: window.windowStart,
+            resets_at: window.resetsAt,
+          },
+        });
+      }
       const requiredRank = STATE_MIN_PRIORITY[window.state];
       const priorityRank = PRIORITY_RANK[priority];
 

--- a/src/sandbox/matrix.ts
+++ b/src/sandbox/matrix.ts
@@ -11,6 +11,7 @@
  * Nível 3: bwrap nivel 2 + applyNetnsToConfig (loopback-only, custom resolv.conf).
  */
 
+import { sendAlertBestEffort } from "@clawde/alerts";
 import type { AgentSandboxConfig } from "./agent-config.ts";
 import type { BwrapConfig, SandboxLevel } from "./bwrap.ts";
 import { applyNetnsToConfig, generateLoopbackResolvConf } from "./netns.ts";
@@ -38,39 +39,53 @@ export interface MaterializedSandbox {
  * Materializa sandbox para uso no worker.
  */
 export function materializeSandbox(input: MaterializeInput): MaterializedSandbox {
-  if (input.agent.level === 1) {
-    return { level: 1, runDirect: true, bwrap: null };
+  try {
+    if (input.agent.level === 1) {
+      return { level: 1, runDirect: true, bwrap: null };
+    }
+
+    // Base config nivel 2.
+    const baseConfig: BwrapConfig = {
+      bwrapPath: input.bwrapPath ?? "/usr/bin/bwrap",
+      readOnlyMounts: [...input.agent.read_only_mounts],
+      readWritePaths: [
+        // Worktree ephemeral é o único path RW.
+        { host: input.workspacePath, sandbox: "/workspace" },
+      ],
+      network: input.agent.network,
+      allowlistBackendAvailable: false,
+      workdir: "/workspace",
+      env: {
+        HOME: "/workspace",
+        PATH: "/usr/bin:/bin",
+        LANG: "C.UTF-8",
+      },
+    };
+
+    if (input.agent.level === 2) {
+      return { level: 2, runDirect: false, bwrap: baseConfig };
+    }
+
+    // Nível 3: aplica netns isolation.
+    const resolvConfPath = generateLoopbackResolvConf(input.stateDir);
+    const netnsConfig = applyNetnsToConfig(baseConfig, {
+      allowedEgress: input.agent.allowed_egress,
+      resolvConfPath,
+    });
+    return { level: 3, runDirect: false, bwrap: netnsConfig };
+  } catch (err) {
+    void sendAlertBestEffort({
+      severity: "high",
+      trigger: "sandbox_violation",
+      cooldownKey: "sandbox_violation",
+      payload: {
+        error: (err as Error).message,
+        level: input.agent.level,
+        network: input.agent.network,
+      },
+    });
+    throw err;
   }
-
-  // Base config nivel 2.
-  const baseConfig: BwrapConfig = {
-    bwrapPath: input.bwrapPath ?? "/usr/bin/bwrap",
-    readOnlyMounts: [...input.agent.read_only_mounts],
-    readWritePaths: [
-      // Worktree ephemeral é o único path RW.
-      { host: input.workspacePath, sandbox: "/workspace" },
-    ],
-    network: input.agent.network,
-    allowlistBackendAvailable: false,
-    workdir: "/workspace",
-    env: {
-      HOME: "/workspace",
-      PATH: "/usr/bin:/bin",
-      LANG: "C.UTF-8",
-    },
-  };
-
-  if (input.agent.level === 2) {
-    return { level: 2, runDirect: false, bwrap: baseConfig };
-  }
-
-  // Nível 3: aplica netns isolation.
-  const resolvConfPath = generateLoopbackResolvConf(input.stateDir);
-  const netnsConfig = applyNetnsToConfig(baseConfig, {
-    allowedEgress: input.agent.allowed_egress,
-    resolvConfPath,
-  });
-  return { level: 3, runDirect: false, bwrap: netnsConfig };
 }
 
 /**

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -1,6 +1,7 @@
 import { homedir, hostname } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { AgentDefinitionError, loadAllAgentDefinitionsWithWarnings } from "@clawde/agents";
+import { sendAlertBestEffort } from "@clawde/alerts";
 import { loadConfig } from "@clawde/config";
 import { closeDb, openDb } from "@clawde/db/client";
 import {
@@ -82,6 +83,12 @@ function assertStartupDbIntegrity(
   }
 
   logger.error("db integrity failed; entering readonly mode", payload);
+  void sendAlertBestEffort({
+    severity: "critical",
+    trigger: "db_corrupted",
+    cooldownKey: "db_corrupted",
+    payload,
+  });
   throw new Error(
     `db integrity failed (integrity_check=${report.integrityCheck}, quick_check=${report.quickCheck}, fk=${report.foreignKeyViolations.length})`,
   );

--- a/tests/unit/alerts/alerts.test.ts
+++ b/tests/unit/alerts/alerts.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dispatchAlert } from "@clawde/alerts";
+import { createEmailAlertChannelFromConfig } from "@clawde/alerts/email";
+import {
+  TelegramAlertChannel,
+  createTelegramAlertChannelFromConfig,
+} from "@clawde/alerts/telegram";
+import type { Alert, AlertChannel } from "@clawde/alerts/types";
+import { type ClawdeConfig, ClawdeConfigSchema } from "@clawde/config";
+
+function makeAlert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    severity: "high",
+    trigger: "smoke_test_fail",
+    cooldownKey: "smoke_test_fail",
+    payload: { reason: "test" },
+    ...overrides,
+  };
+}
+
+describe("alerts/dispatch", () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    tempDirs = [];
+  });
+
+  test("respeita cooldown persistido por cooldownKey", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "clawde-alerts-"));
+    tempDirs.push(stateDir);
+
+    let sends = 0;
+    const channel: AlertChannel = {
+      send: async () => {
+        sends += 1;
+      },
+    };
+
+    const now = new Date("2026-05-01T12:00:00.000Z");
+    const first = await dispatchAlert(makeAlert(), [channel], {
+      stateDir,
+      now: () => now,
+      defaultCooldownMs: 60_000,
+    });
+    expect(first.sent).toBe(true);
+    expect(first.skippedByCooldown).toBe(false);
+    expect(sends).toBe(1);
+
+    const second = await dispatchAlert(makeAlert(), [channel], {
+      stateDir,
+      now: () => new Date("2026-05-01T12:00:10.000Z"),
+      defaultCooldownMs: 60_000,
+    });
+    expect(second.sent).toBe(false);
+    expect(second.skippedByCooldown).toBe(true);
+    expect(sends).toBe(1);
+
+    const third = await dispatchAlert(makeAlert(), [channel], {
+      stateDir,
+      now: () => new Date("2026-05-01T12:01:10.000Z"),
+      defaultCooldownMs: 60_000,
+    });
+    expect(third.sent).toBe(true);
+    expect(third.skippedByCooldown).toBe(false);
+    expect(sends).toBe(2);
+  });
+
+  test("retorna erros de canais sem impedir envio nos demais", async () => {
+    const ok: AlertChannel = { send: async () => {} };
+    const boom: AlertChannel = {
+      send: async () => {
+        throw new Error("channel down");
+      },
+    };
+    const result = await dispatchAlert(makeAlert(), [boom, ok], {
+      stateDir: mkdtempSync(join(tmpdir(), "clawde-alerts-")),
+    });
+    expect(result.sent).toBe(true);
+    expect(result.channelErrors).toHaveLength(1);
+    expect(result.channelErrors[0]).toContain("channel down");
+  });
+});
+
+describe("alerts/telegram", () => {
+  test("envia para Telegram API no formato esperado", async () => {
+    let url = "";
+    let body = "";
+    const fetchMock = (async (u: string | URL | Request, init?: RequestInit) => {
+      url = u.toString();
+      body = String(init?.body ?? "");
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    const channel = new TelegramAlertChannel("token-123", "456", fetchMock);
+    await channel.send(makeAlert({ severity: "critical", trigger: "fatal_log" }));
+    expect(url).toBe("https://api.telegram.org/bottoken-123/sendMessage");
+    expect(body).toContain('"chat_id":"456"');
+    expect(body).toContain("[CRITICAL][fatal_log]");
+  });
+
+  test("createTelegramAlertChannelFromConfig retorna null sem credenciais", () => {
+    const config = ClawdeConfigSchema.parse({
+      telegram: { secret: "abc", allowed_user_ids: [1] },
+    }) as ClawdeConfig;
+    const channel = createTelegramAlertChannelFromConfig(config, {});
+    expect(channel).toBeNull();
+  });
+});
+
+describe("alerts/email", () => {
+  test("createEmailAlertChannelFromConfig retorna null sem seção", () => {
+    const config = ClawdeConfigSchema.parse({});
+    expect(createEmailAlertChannelFromConfig(config, {})).toBeNull();
+  });
+
+  test("createEmailAlertChannelFromConfig cria canal com creds no env", () => {
+    const config = ClawdeConfigSchema.parse({
+      alerts: {
+        email: {
+          smtp_host: "smtp.example.com",
+          smtp_port: 587,
+          smtp_username_credential: "smtp-user",
+          smtp_password_credential: "smtp-pass",
+          from: "clawde@example.com",
+          to: "ops@example.com",
+        },
+      },
+    });
+    const channel = createEmailAlertChannelFromConfig(config, {
+      "SMTP-USER": "ignored",
+      SMTP_USER: "user",
+      SMTP_PASS: "pass",
+    });
+    expect(channel).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes sub-phase P6.4 in EXECUTION_BACKLOG.md.

## Tasks included
- T-134: AlertChannel interface + dispatcher with persisted cooldown locks
- T-135: Telegram alert channel
- T-136: Email alert channel (SMTP + STARTTLS)
- T-137: Wire alert triggers on critical runtime points

## What changed
Added a new alerts module (`src/alerts`) with channel abstractions, dispatch cooldown persistence in `~/.clawde/state/alerts`, and runtime best-effort fanout. Extended config schema for Telegram alert credentials and optional `[alerts.email]`. Wired alert emission in fatal logs, smoke failures, quota critical state, sandbox materialization errors, migration failures, OAuth expiry warnings, and startup DB corruption.

## Acceptance criteria validated
- [x] T-134 criteria
- [x] T-135 criteria
- [x] T-136 criteria
- [x] T-137 criteria

## CI
- [x] `bun run typecheck` clean
- [ ] `bun run lint` clean *(known pre-existing lint debt in P3.2 files/tests unrelated to this PR)*
- [x] `bun test` passing except historical flaky `findExpiredLeases`
  - Run A: 707 pass / 1 fail (flaky `tests/unit/db/task-runs.repo.test.ts::findExpiredLeases`)
  - Run B: 707 pass / 1 fail (same flaky)
- [x] Focused tests for touched areas clean (alerts, smoke-test, worker bootstrap, migrations, logger, quota)

## Notes for reviewer
- `sendAlertBestEffort` is intentionally fail-safe (never breaks caller flow).
- Cooldown lock file path is sanitized from `cooldownKey` and persisted per key.
- `smoke-test` alert checks keep degraded behavior and do not reintroduce global config coupling.
- New unit suite: `tests/unit/alerts/alerts.test.ts`.

## Cross-wave dependencies
- none

🤖 Implemented by Codex