### PR TITLE
P6.6: monthly restore drill

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -58,7 +58,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | merged, PR #31, 2026-05-01 | #31 |
 | P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | merged, PR #32, 2026-05-01 | #32 |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | merged, PR #33, 2026-05-01 | #33 |
-| P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | in-progress, codex | — |
+| P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | in-review, PR #34 | #34 |
 
 **Cross-wave dependencies**:
 - T-008 do P0.1 foi desbloqueado após merge de P1.2 (T-029) e concluído no followup PR #9 (2026-04-29).
@@ -285,9 +285,9 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-140 — merged, PR #33, 2026-05-01
 
 ### P6.6 — Restore drill
-- [ ] T-141 — in-progress, codex
-- [ ] T-142 — in-progress, codex
-- [ ] T-143 — in-progress, codex
+- [x] T-141 — in-review, PR #34
+- [x] T-142 — in-review, PR #34
+- [x] T-143 — in-review, PR #34
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -58,7 +58,7 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 | P6.3 | `task/P6.3-events-retention` | T-131..T-133 | codex | claude (+ operador em T-132) | merged, PR #31, 2026-05-01 | #31 |
 | P6.4 | `task/P6.4-alerts-system` | T-134..T-137 | codex | claude | merged, PR #32, 2026-05-01 | #32 |
 | P6.5 | `task/P6.5-backup-cadence` | T-138..T-140 | codex | claude | merged, PR #33, 2026-05-01 | #33 |
-| P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | pending | — |
+| P6.6 | `task/P6.6-restore-drill` | T-141..T-143 | codex | claude | in-progress, codex | — |
 
 **Cross-wave dependencies**:
 - T-008 do P0.1 foi desbloqueado após merge de P1.2 (T-029) e concluído no followup PR #9 (2026-04-29).
@@ -285,9 +285,9 @@ agrupa tasks relacionadas em commits atômicos (1 commit por T-NNN), com
 - [x] T-140 — merged, PR #33, 2026-05-01
 
 ### P6.6 — Restore drill
-- [ ] T-141 — pending
-- [ ] T-142 — pending
-- [ ] T-143 — pending
+- [ ] T-141 — in-progress, codex
+- [ ] T-142 — in-progress, codex
+- [ ] T-143 — in-progress, codex
 
 ---
 

--- a/deploy/systemd/clawde-restore-drill.service
+++ b/deploy/systemd/clawde-restore-drill.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Clawde restore drill mensal
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/.clawde
+EnvironmentFile=-%h/.clawde/config/clawde.env
+ExecStart=/bin/bash -lc "%h/.clawde/scripts/restore-drill.sh || { %h/.clawde/dist/clawde smoke-test --db /nonexistent/clawde-restore-drill-alert.db --output json >/dev/null 2>&1 || true; exit 1; }"
+
+# Hardening idêntico ao worker (BEST_PRACTICES §10.4)
+PrivateTmp=yes
+ProtectHome=read-only
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+ReadWritePaths=%h/.clawde /tmp
+
+[Install]
+WantedBy=default.target

--- a/deploy/systemd/clawde-restore-drill.timer
+++ b/deploy/systemd/clawde-restore-drill.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Clawde restore drill agendado (mensal dia 1 às 04:30 local)
+
+[Timer]
+OnCalendar=*-*-01 04:30:00
+Unit=clawde-restore-drill.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/restore-drill.sh
+++ b/scripts/restore-drill.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="/tmp/clawde-drill-$RANDOM"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+home_dir="${CLAWDE_HOME:-$HOME/.clawde}"
+weekly_dir="${CLAWDE_BACKUP_WEEKLY_DIR:-$home_dir/backups/weekly}"
+
+mkdir -p "$tmp_dir"
+
+latest_entry="$(
+  find "$weekly_dir" -maxdepth 1 -type f \( -name 'state-*.db' -o -name 'state-*.db.gz' \) -printf '%f\n' \
+    | sort \
+    | tail -n1
+)"
+
+if [[ -z "$latest_entry" ]]; then
+  echo "restore-drill: no backup found in $weekly_dir" >&2
+  exit 1
+fi
+
+latest_path="$weekly_dir/$latest_entry"
+snapshot_db="$tmp_dir/snapshot.db"
+restored_db="$tmp_dir/restored.db"
+
+if [[ "$latest_path" == *.gz ]]; then
+  gunzip -c "$latest_path" > "$snapshot_db"
+else
+  cp "$latest_path" "$snapshot_db"
+fi
+
+sqlite3 "$snapshot_db" ".backup '$restored_db'"
+
+snapshot_ts="$(echo "$latest_entry" | sed -E 's/^state-([0-9]{8}T[0-9]{6}Z)\.db(\.gz)?$/\1/')"
+
+SNAPSHOT_DB="$snapshot_db" RESTORED_DB="$restored_db" SNAPSHOT_TS="$snapshot_ts" bun --eval '
+import { Database } from "bun:sqlite";
+
+const snapshotPath = process.env.SNAPSHOT_DB;
+const restoredPath = process.env.RESTORED_DB;
+if (snapshotPath === undefined || restoredPath === undefined) {
+  console.error("restore-drill: missing DB env paths");
+  process.exit(1);
+}
+
+const tables = ["events", "quota_ledger", "messages"] as const;
+const snapshot = new Database(snapshotPath, { readonly: true });
+const restored = new Database(restoredPath, { readonly: true });
+
+try {
+  const integrity = restored.query<{ integrity_check: string }, []>("PRAGMA integrity_check").get();
+  if ((integrity?.integrity_check ?? "") !== "ok") {
+    console.error(`restore-drill: integrity_check failed (${integrity?.integrity_check ?? "unknown"})`);
+    process.exit(1);
+  }
+
+  for (const table of tables) {
+    const sourceCount = Number(
+      snapshot.query<{ n: number }, []>(`SELECT COUNT(*) AS n FROM ${table}`).get()?.n ?? 0,
+    );
+    const restoredCount = Number(
+      restored.query<{ n: number }, []>(`SELECT COUNT(*) AS n FROM ${table}`).get()?.n ?? 0,
+    );
+    if (sourceCount !== restoredCount) {
+      console.error(
+        `restore-drill: count mismatch table=${table} snapshot=${sourceCount} restored=${restoredCount}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const ts = process.env.SNAPSHOT_TS ?? "unknown";
+  console.log(`restore-drill: OK snapshot_ts=${ts}`);
+} finally {
+  snapshot.close();
+  restored.close();
+}
+'

--- a/tests/integration/restore-drill.test.ts
+++ b/tests/integration/restore-drill.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDb, openDb } from "@clawde/db/client";
+import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
+import { EventsRepo } from "@clawde/db/repositories/events";
+import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
+import { SessionsRepo } from "@clawde/db/repositories/sessions";
+import { deriveSessionId } from "@clawde/domain/session";
+
+function runScript(
+  scriptPath: string,
+  args: ReadonlyArray<string>,
+  env: Record<string, string | undefined>,
+): {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+} {
+  const proc = Bun.spawnSync(["bash", scriptPath, ...args], {
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+describe("restore drill integration", () => {
+  let dir: string;
+  let homeDir: string;
+  let weeklyDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "clawde-restore-drill-"));
+    homeDir = join(dir, "home");
+    weeklyDir = join(homeDir, "backups", "weekly");
+    mkdirSync(weeklyDir, { recursive: true });
+    dbPath = join(homeDir, "state.db");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("drill valida restore do snapshot mesmo com DB live alterado depois do backup", () => {
+    const db = openDb(dbPath);
+    applyPending(db, defaultMigrationsDir());
+    const sessions = new SessionsRepo(db);
+    const sessionId = deriveSessionId({ agent: "default", workingDir: "/tmp/clawde" });
+    sessions.upsert({ sessionId, agent: "default" });
+
+    const events = new EventsRepo(db);
+    const quota = new QuotaLedgerRepo(db);
+    events.insert({
+      taskRunId: null,
+      sessionId,
+      traceId: "trace-backup",
+      spanId: null,
+      kind: "enqueue",
+      payload: { source: "restore-drill-test" },
+    });
+    quota.insert({
+      msgsConsumed: 1,
+      windowStart: quota.currentWindowStart(),
+      plan: "max5x",
+      peakMultiplier: 1.0,
+      taskRunId: null,
+    });
+    db.run("INSERT INTO messages (session_id, role, content) VALUES (?, ?, ?)", [
+      sessionId,
+      "user",
+      "before backup",
+    ]);
+    closeDb(db);
+
+    const commonEnv = {
+      ...(process.env as Record<string, string | undefined>),
+      CLAWDE_HOME: homeDir,
+      CLAWDE_DB_PATH: dbPath,
+    };
+
+    const snapshot = runScript("scripts/backup-snapshot.sh", [weeklyDir], commonEnv);
+    expect(snapshot.exitCode).toBe(0);
+    expect(existsSync(weeklyDir)).toBe(true);
+    expect(readdirSync(weeklyDir).some((n) => n.startsWith("state-") && n.endsWith(".db"))).toBe(
+      true,
+    );
+
+    // Muta o DB live após o snapshot para garantir que drill compara snapshot vs restore.
+    const dbAfter = openDb(dbPath);
+    const eventsAfter = new EventsRepo(dbAfter);
+    const quotaAfter = new QuotaLedgerRepo(dbAfter);
+    eventsAfter.insert({
+      taskRunId: null,
+      sessionId,
+      traceId: "trace-after",
+      spanId: null,
+      kind: "task_start",
+      payload: { source: "post-backup" },
+    });
+    quotaAfter.insert({
+      msgsConsumed: 5,
+      windowStart: quotaAfter.currentWindowStart(),
+      plan: "max5x",
+      peakMultiplier: 1.0,
+      taskRunId: null,
+    });
+    dbAfter.run("INSERT INTO messages (session_id, role, content) VALUES (?, ?, ?)", [
+      sessionId,
+      "assistant",
+      "after backup",
+    ]);
+    closeDb(dbAfter);
+
+    const drill = runScript("scripts/restore-drill.sh", [], commonEnv);
+    expect(drill.exitCode).toBe(0);
+    expect(drill.stdout).toContain("restore-drill: OK");
+  });
+});

--- a/tests/unit/sandbox/systemd.test.ts
+++ b/tests/unit/sandbox/systemd.test.ts
@@ -178,4 +178,22 @@ describe("deploy/systemd unit files reais", () => {
     expect(statSync(snapshotPath).mode & 0o111).toBeGreaterThan(0);
     expect(statSync(prunePath).mode & 0o111).toBeGreaterThan(0);
   });
+
+  test("clawde-restore-drill.timer roda mensal dia 1 às 04:30", () => {
+    const content = readUnit("clawde-restore-drill.timer");
+    expect(content).toContain("OnCalendar=*-*-01 04:30:00");
+    expect(content).toContain("Unit=clawde-restore-drill.service");
+  });
+
+  test("clawde-restore-drill.service roda script e emite alerta high em falha", () => {
+    const content = readUnit("clawde-restore-drill.service");
+    expect(content).toContain("scripts/restore-drill.sh ||");
+    expect(content).toContain("clawde smoke-test --db /nonexistent/clawde-restore-drill-alert.db");
+    expect(content).toContain("ReadWritePaths=%h/.clawde /tmp");
+  });
+
+  test("restore-drill script tem exec bit", () => {
+    const scriptPath = join(import.meta.dirname, "../../../scripts/restore-drill.sh");
+    expect(statSync(scriptPath).mode & 0o111).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
Closes sub-phase P6.6 in EXECUTION_BACKLOG.md.

## Tasks included
- T-141: `scripts/restore-drill.sh`
- T-142: `clawde-restore-drill.{service,timer}`
- T-143: `tests/integration/restore-drill.test.ts`

## What changed
Added a monthly restore-drill script that restores the latest weekly backup into a temporary drill directory, runs `PRAGMA integrity_check` using `bun:sqlite`, and verifies append-only table counts (`events`, `quota_ledger`, `messages`) between snapshot and restored DB. Added a monthly systemd timer/service at `*-*-01 04:30:00`. On restore-drill failure, the service triggers a high-severity alert path via `clawde smoke-test` forced failure before returning non-zero. Added integration coverage that proves the drill validates snapshot-vs-restore correctly even when the live DB changes after backup.

## Acceptance criteria validated
- [x] T-141 criteria
- [x] T-142 criteria
- [x] T-143 criteria

## CI
- [x] `bun run typecheck` clean
- [ ] `bun run lint` clean *(fails only on pre-existing P3.2 lint debt in unrelated files)*
- [x] `bun test` executed
  - 716 pass / 2 skip / 1 fail
  - only failure: historical flaky `tests/unit/db/task-runs.repo.test.ts::findExpiredLeases`

## Tests added/updated
- New: `tests/integration/restore-drill.test.ts`
- Updated: `tests/unit/sandbox/systemd.test.ts`
  - restore drill timer schedule
  - restore drill service command and failure alert path
  - exec bit check for `scripts/restore-drill.sh`

## Notes for reviewer
- `scripts/restore-drill.sh` is committed with executable bit (`100755`) to avoid systemd permission regressions.
- Drill cleanup is guaranteed via `trap` on exit.

## Cross-wave dependencies
- Uses backup artifacts from P6.5 (`scripts/backup-snapshot.sh` + weekly backups).

🤖 Implemented by Codex