### PR TITLE
chore: P3.2 followup — clean lint debt from PR #25

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -6,9 +6,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { parse as parseTOML } from "smol-toml";
 import { ClawdeConfigSchema } from "@clawde/config";
 import { ConfigError, loadConfig } from "@clawde/config";
+import { parse as parseTOML } from "smol-toml";
 import { type OutputFormat, emit, emitErr } from "../output.ts";
 
 export interface ConfigShowOptions {

--- a/src/cli/commands/panic.ts
+++ b/src/cli/commands/panic.ts
@@ -133,14 +133,16 @@ export function fakeSystemdController(): FakeSystemdController {
     async stop(unit) {
       calls.push({ op: "stop", unit });
       const fail = fails.get(failKey("stop", unit));
-      if (fail !== undefined) return { ok: false, ...(fail.detail !== undefined ? { detail: fail.detail } : {}) };
+      if (fail !== undefined)
+        return { ok: false, ...(fail.detail !== undefined ? { detail: fail.detail } : {}) };
       active.set(unit, false);
       return { ok: true };
     },
     async start(unit) {
       calls.push({ op: "start", unit });
       const fail = fails.get(failKey("start", unit));
-      if (fail !== undefined) return { ok: false, ...(fail.detail !== undefined ? { detail: fail.detail } : {}) };
+      if (fail !== undefined)
+        return { ok: false, ...(fail.detail !== undefined ? { detail: fail.detail } : {}) };
       active.set(unit, true);
       return { ok: true };
     },
@@ -230,7 +232,8 @@ export async function runPanicStop(options: PanicStopOptions): Promise<number> {
       `host/pid:     ${r.lock.hostname}/${r.lock.pid}`,
       ...(r.lock.reason !== undefined ? [`reason:       ${r.lock.reason}`] : []),
       ...r.stops.map(
-        (s) => `[${s.ok ? "OK " : "FAIL"}] systemctl stop ${s.unit}${s.detail !== undefined ? `: ${s.detail}` : ""}`,
+        (s) =>
+          `[${s.ok ? "OK " : "FAIL"}] systemctl stop ${s.unit}${s.detail !== undefined ? `: ${s.detail}` : ""}`,
       ),
       `overall: ${r.ok ? "OK" : "DEGRADED"}`,
     ];
@@ -269,8 +272,7 @@ export interface PanicResumeReport {
 export async function runPanicResume(options: PanicResumeOptions): Promise<number> {
   const sd = options.systemd ?? realSystemdController();
   const diagnose =
-    options.diagnose ??
-    (async () => captureDiagnoseAll(options.dbPath, options.agentsRoot));
+    options.diagnose ?? (async () => captureDiagnoseAll(options.dbPath, options.agentsRoot));
   const diagnoseReport = await diagnose();
 
   if (diagnoseReport.status !== "ok") {
@@ -328,10 +330,7 @@ function emitResume(format: OutputFormat, report: PanicResumeReport): void {
   });
 }
 
-async function captureDiagnoseAll(
-  dbPath: string,
-  agentsRoot?: string,
-): Promise<DiagnoseReport> {
+async function captureDiagnoseAll(dbPath: string, agentsRoot?: string): Promise<DiagnoseReport> {
   // Captura stdout do runDiagnose pra extrair report estruturado sem
   // duplicar lógica. format=json garante JSON parseável.
   const orig = process.stdout.write.bind(process.stdout);

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -3,8 +3,8 @@
  * persistentes do SDK. Sub-fase P3.2 (T-107, T-108).
  */
 
-import type { Session, SessionState } from "@clawde/domain/session";
 import { closeDb, openDb } from "@clawde/db/client";
+import type { Session, SessionState } from "@clawde/domain/session";
 import { type OutputFormat, emit, emitErr } from "../output.ts";
 
 export interface SessionsListOptions {
@@ -104,9 +104,7 @@ export function runSessionsShow(options: SessionsShowOptions): number {
       }
       const session = rowToSession(row);
       const eventsRow = db
-        .query<{ n: number }, [string]>(
-          `SELECT COUNT(*) AS n FROM events WHERE session_id = ?`,
-        )
+        .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM events WHERE session_id = ?")
         .get(options.sessionId);
       const eventsCount = eventsRow?.n ?? 0;
       const warnings: string[] = [];

--- a/tests/integration/config-cmd.test.ts
+++ b/tests/integration/config-cmd.test.ts
@@ -49,17 +49,13 @@ describe("cli/commands/config show+validate", () => {
     if (prevConfigEnv !== undefined) {
       process.env.CLAWDE_CONFIG = prevConfigEnv;
     } else {
-      delete process.env.CLAWDE_CONFIG;
+      Reflect.deleteProperty(process.env, "CLAWDE_CONFIG");
     }
     rmSync(dir, { recursive: true, force: true });
   });
 
   test("show com config válido retorna 0 + report estruturado", async () => {
-    writeFileSync(
-      configPath,
-      `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`,
-      "utf-8",
-    );
+    writeFileSync(configPath, `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`, "utf-8");
     const { exit, stdout } = await captureOutput(() =>
       runConfigShow({ format: "json", path: configPath }),
     );
@@ -95,11 +91,7 @@ describe("cli/commands/config show+validate", () => {
   });
 
   test("validate retorna 0 em TOML válido", async () => {
-    writeFileSync(
-      configPath,
-      `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`,
-      "utf-8",
-    );
+    writeFileSync(configPath, `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`, "utf-8");
     const { exit, stdout } = await captureOutput(() =>
       runConfigValidate({ format: "json", path: configPath }),
     );
@@ -148,17 +140,13 @@ describe("cli/commands/config show+validate", () => {
       if (prevPlan !== undefined) {
         process.env.CLAWDE_QUOTA_PLAN = prevPlan;
       } else {
-        delete process.env.CLAWDE_QUOTA_PLAN;
+        Reflect.deleteProperty(process.env, "CLAWDE_QUOTA_PLAN");
       }
     }
   });
 
   test("show: env vence toml para o mesmo campo", async () => {
-    writeFileSync(
-      configPath,
-      `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`,
-      "utf-8",
-    );
+    writeFileSync(configPath, `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`, "utf-8");
     const prevLevel = process.env.CLAWDE_LOG_LEVEL;
     process.env.CLAWDE_LOG_LEVEL = "DEBUG";
     try {
@@ -173,17 +161,13 @@ describe("cli/commands/config show+validate", () => {
       if (prevLevel !== undefined) {
         process.env.CLAWDE_LOG_LEVEL = prevLevel;
       } else {
-        delete process.env.CLAWDE_LOG_LEVEL;
+        Reflect.deleteProperty(process.env, "CLAWDE_LOG_LEVEL");
       }
     }
   });
 
   test("show: campo no TOML mas com env var vazia continua toml (não env)", async () => {
-    writeFileSync(
-      configPath,
-      `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`,
-      "utf-8",
-    );
+    writeFileSync(configPath, `[clawde]\nhome = "${dir}"\nlog_level = "INFO"\n`, "utf-8");
     const prevLevel = process.env.CLAWDE_LOG_LEVEL;
     process.env.CLAWDE_LOG_LEVEL = "";
     try {
@@ -197,7 +181,7 @@ describe("cli/commands/config show+validate", () => {
       if (prevLevel !== undefined) {
         process.env.CLAWDE_LOG_LEVEL = prevLevel;
       } else {
-        delete process.env.CLAWDE_LOG_LEVEL;
+        Reflect.deleteProperty(process.env, "CLAWDE_LOG_LEVEL");
       }
     }
   });

--- a/tests/integration/panic-stop.test.ts
+++ b/tests/integration/panic-stop.test.ts
@@ -84,7 +84,10 @@ describe("cli/commands/panic runPanicStop", () => {
         )
         .all();
       expect(rows).toHaveLength(1);
-      const payload = JSON.parse(rows[0]!.payload) as Record<string, unknown>;
+      const first = rows[0];
+      if (first === undefined)
+        throw new Error("unreachable: rows[0] missing after toHaveLength(1)");
+      const payload = JSON.parse(first.payload) as Record<string, unknown>;
       expect(payload.reason).toBe("incident #42");
       expect(payload.already_locked).toBe(false);
     } finally {
@@ -109,7 +112,9 @@ describe("cli/commands/panic runPanicStop", () => {
     const db = openDb(dbPath);
     try {
       const events = new EventsRepo(db);
-      const all = events.querySince("1970-01-01T00:00:00Z", 100).filter((e) => e.kind === "panic_stop");
+      const all = events
+        .querySince("1970-01-01T00:00:00Z", 100)
+        .filter((e) => e.kind === "panic_stop");
       expect(all).toHaveLength(2);
     } finally {
       closeDb(db);

--- a/tests/integration/sessions-cmd.test.ts
+++ b/tests/integration/sessions-cmd.test.ts
@@ -55,9 +55,7 @@ describe("cli/commands/sessions list+show", () => {
   });
 
   test("list em DB sem sessões retorna stdout '(no sessions)'", async () => {
-    const { exit, stdout } = await captureOutput(() =>
-      runSessionsList({ dbPath, format: "text" }),
-    );
+    const { exit, stdout } = await captureOutput(() => runSessionsList({ dbPath, format: "text" }));
     expect(exit).toBe(0);
     expect(stdout).toContain("(no sessions)");
   });
@@ -68,9 +66,7 @@ describe("cli/commands/sessions list+show", () => {
     repo.upsert({ sessionId: "sess-b", agent: "verifier" });
     repo.markUsed("sess-a", 3, 120);
 
-    const { exit, stdout } = await captureOutput(() =>
-      runSessionsList({ dbPath, format: "json" }),
-    );
+    const { exit, stdout } = await captureOutput(() => runSessionsList({ dbPath, format: "json" }));
     expect(exit).toBe(0);
     const list = JSON.parse(stdout) as Array<{ sessionId: string; msgCount: number }>;
     expect(list).toHaveLength(2);


### PR DESCRIPTION
## Summary

Limpa o débito de lint deixado em arquivos do P3.2 (PR #25) que foi catalogado como followup nos reviews dos PRs da Wave 6 (#29..#34).

## Mudanças

- **Auto-fixes do biome** (format + organizeImports) em:
  - `src/cli/commands/{config,panic,sessions}.ts`
  - `tests/integration/{config-cmd,panic-stop,sessions-cmd}.test.ts`
- **`sessions.ts:107`**: template literal sem interpolação → string literal padrão.
- **`config-cmd.test.ts` (4 lugares)**: `delete process.env.X` → `Reflect.deleteProperty(process.env, "X")`. Mesma semântica, sem disparar `lint/performance/noDelete`. Bun-compatible.
- **`panic-stop.test.ts:87`**: `rows[0]!.payload` (non-null assertion) → guard explícito `if (first === undefined) throw new Error("unreachable: ...")`.

## CI

- [x] `bun run typecheck` clean.
- [x] `bun run lint`: **0 errors** (era 12). 1 warning pré-existente em `receiver-bootstrap.test.ts` (noConsole) que existia antes do P3.2 — fora do escopo deste PR.
- [x] `bun test`: 717 pass / 2 skip / 0 fail (= 719 total). Sem regressão.

## Out of scope

- 1 warning `noConsole` em `tests/integration/receiver-bootstrap.test.ts:32`. Pré-existente ao P3.2 (já existia em `worker-bootstrap.test.ts` mas P6.2 limpou esse). Vale outro followup mínimo se quiser zerar warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)