### PR TITLE
feat(telegram): reply automático ao remetente após task concluída

### DIFF
--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -3,31 +3,38 @@
  * Padrões inspirados em claude-mem/src/sdk/parser.ts.
  */
 
-import type { ContentBlock, ParsedMessage, TextBlock, ToolUseBlock } from "./types.ts";
+import type {
+	ContentBlock,
+	ParsedMessage,
+	TextBlock,
+	ToolUseBlock,
+} from "./types.ts";
 
 export function isTextBlock(b: ContentBlock): b is TextBlock {
-  return b.type === "text";
+	return b.type === "text";
 }
 
 export function isToolUseBlock(b: ContentBlock): b is ToolUseBlock {
-  return b.type === "tool_use";
+	return b.type === "tool_use";
 }
 
 /**
  * Extrai texto concatenado de uma mensagem (skip tool_use/tool_result).
  */
 export function extractText(message: ParsedMessage): string {
-  return message.blocks
-    .filter(isTextBlock)
-    .map((b) => b.text)
-    .join("\n");
+	return message.blocks
+		.filter(isTextBlock)
+		.map((b) => b.text)
+		.join("\n");
 }
 
 /**
  * Lista tool_uses de uma mensagem.
  */
-export function extractToolUses(message: ParsedMessage): ReadonlyArray<ToolUseBlock> {
-  return message.blocks.filter(isToolUseBlock);
+export function extractToolUses(
+	message: ParsedMessage,
+): ReadonlyArray<ToolUseBlock> {
+	return message.blocks.filter(isToolUseBlock);
 }
 
 /**
@@ -37,46 +44,65 @@ export function extractToolUses(message: ParsedMessage): ReadonlyArray<ToolUseBl
  * Espera entrada com `{type, role?, content?: array | string}`.
  */
 export function parseRawMessage(raw: unknown): ParsedMessage | null {
-  if (raw === null || typeof raw !== "object") return null;
-  const obj = raw as Record<string, unknown>;
-  const role = (obj.role ?? obj.message_role ?? "assistant") as string;
-  if (role !== "user" && role !== "assistant" && role !== "system" && role !== "tool") {
-    return null;
-  }
+	if (raw === null || typeof raw !== "object") return null;
+	const obj = raw as Record<string, unknown>;
 
-  const content = obj.content ?? obj.text ?? obj.message;
-  const blocks: ContentBlock[] = [];
+	// SDKAssistantMessage: {type: 'assistant', message: BetaMessage, uuid, session_id}
+	// The actual content is nested inside message.content — unwrap and recurse.
+	if (
+		obj.type === "assistant" &&
+		obj.message !== null &&
+		typeof obj.message === "object"
+	) {
+		return parseRawMessage(obj.message);
+	}
 
-  if (typeof content === "string") {
-    blocks.push({ type: "text", text: content });
-  } else if (Array.isArray(content)) {
-    for (const item of content) {
-      if (typeof item === "string") {
-        blocks.push({ type: "text", text: item });
-        continue;
-      }
-      if (item === null || typeof item !== "object") continue;
-      const b = item as Record<string, unknown>;
-      const btype = b.type;
-      if (btype === "text" && typeof b.text === "string") {
-        blocks.push({ type: "text", text: b.text });
-      } else if (btype === "tool_use") {
-        blocks.push({
-          type: "tool_use",
-          name: String(b.name ?? "unknown"),
-          input: (b.input ?? {}) as Readonly<Record<string, unknown>>,
-          id: String(b.id ?? ""),
-        });
-      } else if (btype === "tool_result") {
-        blocks.push({
-          type: "tool_result",
-          toolUseId: String(b.tool_use_id ?? b.toolUseId ?? ""),
-          content: typeof b.content === "string" ? b.content : JSON.stringify(b.content),
-          isError: Boolean(b.is_error ?? b.isError ?? false),
-        });
-      }
-    }
-  }
+	const role = (obj.role ?? obj.message_role ?? "assistant") as string;
+	if (
+		role !== "user" &&
+		role !== "assistant" &&
+		role !== "system" &&
+		role !== "tool"
+	) {
+		return null;
+	}
 
-  return { role: role as ParsedMessage["role"], blocks, raw };
+	const content = obj.content ?? obj.text ?? obj.message;
+	const blocks: ContentBlock[] = [];
+
+	if (typeof content === "string") {
+		blocks.push({ type: "text", text: content });
+	} else if (Array.isArray(content)) {
+		for (const item of content) {
+			if (typeof item === "string") {
+				blocks.push({ type: "text", text: item });
+				continue;
+			}
+			if (item === null || typeof item !== "object") continue;
+			const b = item as Record<string, unknown>;
+			const btype = b.type;
+			if (btype === "text" && typeof b.text === "string") {
+				blocks.push({ type: "text", text: b.text });
+			} else if (btype === "tool_use") {
+				blocks.push({
+					type: "tool_use",
+					name: String(b.name ?? "unknown"),
+					input: (b.input ?? {}) as Readonly<Record<string, unknown>>,
+					id: String(b.id ?? ""),
+				});
+			} else if (btype === "tool_result") {
+				blocks.push({
+					type: "tool_result",
+					toolUseId: String(b.tool_use_id ?? b.toolUseId ?? ""),
+					content:
+						typeof b.content === "string"
+							? b.content
+							: JSON.stringify(b.content),
+					isError: Boolean(b.is_error ?? b.isError ?? false),
+				});
+			}
+		}
+	}
+
+	return { role: role as ParsedMessage["role"], blocks, raw };
 }

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -1,13 +1,16 @@
 import { homedir, hostname } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { AgentDefinitionError, loadAllAgentDefinitionsWithWarnings } from "@clawde/agents";
+import {
+	AgentDefinitionError,
+	loadAllAgentDefinitionsWithWarnings,
+} from "@clawde/agents";
 import { sendAlertBestEffort } from "@clawde/alerts";
 import { loadConfig } from "@clawde/config";
 import { closeDb, openDb } from "@clawde/db/client";
 import {
-  SLOW_INTEGRITY_CHECK_MS,
-  isDbIntegrityOk,
-  runDbIntegrityChecks,
+	isDbIntegrityOk,
+	runDbIntegrityChecks,
+	SLOW_INTEGRITY_CHECK_MS,
 } from "@clawde/db/integrity";
 import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
 import { EventsRepo } from "@clawde/db/repositories/events";
@@ -15,204 +18,226 @@ import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, setMinLevel } from "@clawde/log";
-import { QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
+import { makeQuotaPolicy, QuotaTracker } from "@clawde/quota";
 import { RealAgentClient } from "@clawde/sdk";
-import { LeaseManager, type RunnerDeps, makeReconciler, processNextPending } from "./index.ts";
+import {
+	LeaseManager,
+	makeReconciler,
+	processNextPending,
+	type RunnerDeps,
+} from "./index.ts";
+import type { ProcessResult } from "./runner.ts";
+import { sendTelegramReply } from "./telegram-reply.ts";
 
 const DEFAULT_MAX_TASKS = 50;
 
 function expandHome(p: string): string {
-  if (p.startsWith("~/") || p === "~") return p.replace(/^~/, homedir());
-  return p;
+	if (p.startsWith("~/") || p === "~") return p.replace(/^~/, homedir());
+	return p;
 }
 
-export function parseMaxTasks(argv: ReadonlyArray<string>, fallback = DEFAULT_MAX_TASKS): number {
-  const idx = argv.indexOf("--max-tasks");
-  if (idx < 0 || idx + 1 >= argv.length) return fallback;
-  const raw = argv[idx + 1];
-  if (raw === undefined) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+export function parseMaxTasks(
+	argv: ReadonlyArray<string>,
+	fallback = DEFAULT_MAX_TASKS,
+): number {
+	const idx = argv.indexOf("--max-tasks");
+	if (idx < 0 || idx + 1 >= argv.length) return fallback;
+	const raw = argv[idx + 1];
+	if (raw === undefined) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 export function parseDryRun(argv: ReadonlyArray<string>): boolean {
-  return argv.includes("--dry-run");
+	return argv.includes("--dry-run");
 }
 
 export type LoopExitReason = "empty" | "deferred" | "max_tasks";
 
 export interface LoopResult {
-  readonly processed: number;
-  readonly exitReason: LoopExitReason;
+	readonly processed: number;
+	readonly exitReason: LoopExitReason;
 }
 
 function assertStartupDbIntegrity(
-  db: ReturnType<typeof openDb>,
-  logger: ReturnType<typeof createLogger>,
+	db: ReturnType<typeof openDb>,
+	logger: ReturnType<typeof createLogger>,
 ): void {
-  const report = runDbIntegrityChecks(db);
-  if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
-    logger.warn("startup integrity_check slow", {
-      elapsed_ms: report.elapsedMs,
-      threshold_ms: SLOW_INTEGRITY_CHECK_MS,
-    });
-  }
-  if (isDbIntegrityOk(report)) {
-    return;
-  }
+	const report = runDbIntegrityChecks(db);
+	if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
+		logger.warn("startup integrity_check slow", {
+			elapsed_ms: report.elapsedMs,
+			threshold_ms: SLOW_INTEGRITY_CHECK_MS,
+		});
+	}
+	if (isDbIntegrityOk(report)) {
+		return;
+	}
 
-  const payload = {
-    integrity_check: report.integrityCheck,
-    quick_check: report.quickCheck,
-    foreign_key_violations: report.foreignKeyViolations.length,
-    elapsed_ms: report.elapsedMs,
-  } as const;
-  try {
-    new EventsRepo(db).insert({
-      taskRunId: null,
-      sessionId: null,
-      traceId: null,
-      spanId: null,
-      kind: "db_corrupted",
-      payload,
-    });
-  } catch (err) {
-    logger.error("failed to persist db_corrupted event", {
-      error: (err as Error).message,
-    });
-  }
+	const payload = {
+		integrity_check: report.integrityCheck,
+		quick_check: report.quickCheck,
+		foreign_key_violations: report.foreignKeyViolations.length,
+		elapsed_ms: report.elapsedMs,
+	} as const;
+	try {
+		new EventsRepo(db).insert({
+			taskRunId: null,
+			sessionId: null,
+			traceId: null,
+			spanId: null,
+			kind: "db_corrupted",
+			payload,
+		});
+	} catch (err) {
+		logger.error("failed to persist db_corrupted event", {
+			error: (err as Error).message,
+		});
+	}
 
-  logger.error("db integrity failed; entering readonly mode", payload);
-  void sendAlertBestEffort({
-    severity: "critical",
-    trigger: "db_corrupted",
-    cooldownKey: "db_corrupted",
-    payload,
-  });
-  throw new Error(
-    `db integrity failed (integrity_check=${report.integrityCheck}, quick_check=${report.quickCheck}, fk=${report.foreignKeyViolations.length})`,
-  );
+	logger.error("db integrity failed; entering readonly mode", payload);
+	void sendAlertBestEffort({
+		severity: "critical",
+		trigger: "db_corrupted",
+		cooldownKey: "db_corrupted",
+		payload,
+	});
+	throw new Error(
+		`db integrity failed (integrity_check=${report.integrityCheck}, quick_check=${report.quickCheck}, fk=${report.foreignKeyViolations.length})`,
+	);
 }
 
-export async function runProcessLoop(deps: RunnerDeps, maxTasks: number): Promise<LoopResult> {
-  let processed = 0;
-  while (processed < maxTasks) {
-    const result = await processNextPending(deps);
-    if (result === null) return { processed, exitReason: "empty" };
-    if (result.agentResult.stopReason === "deferred") {
-      return { processed, exitReason: "deferred" };
-    }
-    processed += 1;
-  }
-  return { processed, exitReason: "max_tasks" };
+export async function runProcessLoop(
+	deps: RunnerDeps,
+	maxTasks: number,
+	onResult?: (result: ProcessResult) => Promise<void>,
+): Promise<LoopResult> {
+	let processed = 0;
+	while (processed < maxTasks) {
+		const result = await processNextPending(deps);
+		if (result === null) return { processed, exitReason: "empty" };
+		if (result.agentResult.stopReason === "deferred") {
+			return { processed, exitReason: "deferred" };
+		}
+		if (onResult !== undefined) {
+			await onResult(result);
+		}
+		processed += 1;
+	}
+	return { processed, exitReason: "max_tasks" };
 }
 
 export async function bootstrap(
-  argv: ReadonlyArray<string> = process.argv.slice(2),
+	argv: ReadonlyArray<string> = process.argv.slice(2),
 ): Promise<void> {
-  const config = loadConfig();
-  setMinLevel(config.clawde.log_level);
-  const logger = createLogger({ service: "worker" });
-  const dbPath = join(expandHome(config.clawde.home), "state.db");
-  const db = openDb(dbPath);
-  try {
-    applyPending(db, defaultMigrationsDir());
-    assertStartupDbIntegrity(db, logger);
-    const tasksRepo = new TasksRepo(db);
-    const runsRepo = new TaskRunsRepo(db);
-    const eventsRepo = new EventsRepo(db);
-    const quotaTracker = new QuotaTracker(new QuotaLedgerRepo(db));
-    const quotaPolicy = makeQuotaPolicy();
-    const leaseManager = new LeaseManager(runsRepo, eventsRepo, {
-      leaseSeconds: config.worker.lease_seconds,
-      heartbeatSeconds: config.worker.heartbeat_seconds,
-    });
-    const reconciler = makeReconciler(runsRepo, eventsRepo, {
-      tasksRepo,
-      workspaceTmpRoot: "/tmp",
-    });
-    const agentsRoot = join(expandHome(config.clawde.home), "agents");
-    const agentDefs = (() => {
-      try {
-        return loadAllAgentDefinitionsWithWarnings(agentsRoot, {
-          onWarning: (warning) => {
-            if (warning.kind === "bash_disallowed_by_sandbox_level") {
-              logger.warn("agent policy mismatch: Bash will be blocked at runtime", {
-                agent: warning.agentName,
-                sandbox_level: warning.sandboxLevel,
-                hint: "Set sandbox level to 1 or remove Bash from allowedTools (ADR 0015 / T-050).",
-              });
-            }
-          },
-        });
-      } catch (err) {
-        if (err instanceof AgentDefinitionError) {
-          const agentName = basename(dirname(err.agentPath));
-          throw new Error(`agent ${agentName} invalid: ${err.message}`);
-        }
-        throw err;
-      }
-    })();
-    const agentDefByName = new Map(agentDefs.map((d) => [d.name, d] as const));
-    const agentClient = new RealAgentClient();
-    const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
-    const reconcileResult = reconciler.reconcile(workerId);
-    logger.info("startup reconcile", {
-      expired_count: reconcileResult.expired.length,
-      reenqueued_count: reconcileResult.reenqueued.length,
-      cleaned_orphans: reconcileResult.cleanedOrphans,
-    });
-    const maxTasks = parseMaxTasks(argv);
-    const dryRun = parseDryRun(argv);
-    const queueSize = tasksRepo.findPending(1000).length;
-    const quotaState = quotaTracker.currentWindow().state;
-    logger.info("worker bootstrap state", {
-      dry_run: dryRun,
-      agents_loaded: agentDefs.length,
-      queue_size: queueSize,
-      quota_state: quotaState,
-    });
+	const config = loadConfig();
+	setMinLevel(config.clawde.log_level);
+	const logger = createLogger({ service: "worker" });
+	const dbPath = join(expandHome(config.clawde.home), "state.db");
+	const db = openDb(dbPath);
+	try {
+		applyPending(db, defaultMigrationsDir());
+		assertStartupDbIntegrity(db, logger);
+		const tasksRepo = new TasksRepo(db);
+		const runsRepo = new TaskRunsRepo(db);
+		const eventsRepo = new EventsRepo(db);
+		const quotaTracker = new QuotaTracker(new QuotaLedgerRepo(db));
+		const quotaPolicy = makeQuotaPolicy();
+		const leaseManager = new LeaseManager(runsRepo, eventsRepo, {
+			leaseSeconds: config.worker.lease_seconds,
+			heartbeatSeconds: config.worker.heartbeat_seconds,
+		});
+		const reconciler = makeReconciler(runsRepo, eventsRepo, {
+			tasksRepo,
+			workspaceTmpRoot: "/tmp",
+		});
+		const agentsRoot = join(expandHome(config.clawde.home), "agents");
+		const agentDefs = (() => {
+			try {
+				return loadAllAgentDefinitionsWithWarnings(agentsRoot, {
+					onWarning: (warning) => {
+						if (warning.kind === "bash_disallowed_by_sandbox_level") {
+							logger.warn(
+								"agent policy mismatch: Bash will be blocked at runtime",
+								{
+									agent: warning.agentName,
+									sandbox_level: warning.sandboxLevel,
+									hint: "Set sandbox level to 1 or remove Bash from allowedTools (ADR 0015 / T-050).",
+								},
+							);
+						}
+					},
+				});
+			} catch (err) {
+				if (err instanceof AgentDefinitionError) {
+					const agentName = basename(dirname(err.agentPath));
+					throw new Error(`agent ${agentName} invalid: ${err.message}`);
+				}
+				throw err;
+			}
+		})();
+		const agentDefByName = new Map(agentDefs.map((d) => [d.name, d] as const));
+		const agentClient = new RealAgentClient();
+		const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
+		const reconcileResult = reconciler.reconcile(workerId);
+		logger.info("startup reconcile", {
+			expired_count: reconcileResult.expired.length,
+			reenqueued_count: reconcileResult.reenqueued.length,
+			cleaned_orphans: reconcileResult.cleanedOrphans,
+		});
+		const maxTasks = parseMaxTasks(argv);
+		const dryRun = parseDryRun(argv);
+		const queueSize = tasksRepo.findPending(1000).length;
+		const quotaState = quotaTracker.currentWindow().state;
+		logger.info("worker bootstrap state", {
+			dry_run: dryRun,
+			agents_loaded: agentDefs.length,
+			queue_size: queueSize,
+			quota_state: quotaState,
+		});
 
-    if (dryRun) {
-      logger.info("worker dry-run complete", {
-        agents_loaded: agentDefs.length,
-        queue_size: queueSize,
-        quota_state: quotaState,
-      });
-      return;
-    }
+		if (dryRun) {
+			logger.info("worker dry-run complete", {
+				agents_loaded: agentDefs.length,
+				queue_size: queueSize,
+				quota_state: quotaState,
+			});
+			return;
+		}
 
-    const loop = await runProcessLoop(
-      {
-        tasksRepo,
-        runsRepo,
-        eventsRepo,
-        leaseManager,
-        quotaTracker,
-        quotaPolicy,
-        agentClient,
-        logger,
-        workerId,
-        workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
-        resolveAgentDefinition: async (agent) => agentDefByName.get(agent) ?? null,
-      },
-      maxTasks,
-    );
-    logger.info("worker idle", {
-      processed: loop.processed,
-      max_tasks: maxTasks,
-      exit_reason: loop.exitReason,
-    });
-  } finally {
-    closeDb(db);
-  }
+		const loop = await runProcessLoop(
+			{
+				tasksRepo,
+				runsRepo,
+				eventsRepo,
+				leaseManager,
+				quotaTracker,
+				quotaPolicy,
+				agentClient,
+				logger,
+				workerId,
+				workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
+				resolveAgentDefinition: async (agent) =>
+					agentDefByName.get(agent) ?? null,
+			},
+			maxTasks,
+			(result) => sendTelegramReply(result.task, result.agentResult, logger),
+		);
+		logger.info("worker idle", {
+			processed: loop.processed,
+			max_tasks: maxTasks,
+			exit_reason: loop.exitReason,
+		});
+	} finally {
+		closeDb(db);
+	}
 }
 
 if (import.meta.main) {
-  bootstrap()
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error((err as Error).message);
-      process.exit(1);
-    });
+	bootstrap()
+		.then(() => process.exit(0))
+		.catch((err) => {
+			console.error((err as Error).message);
+			process.exit(1);
+		});
 }

--- a/src/worker/telegram-reply.ts
+++ b/src/worker/telegram-reply.ts
@@ -1,0 +1,66 @@
+import type { Task } from "@clawde/domain/task";
+import type { Logger } from "@clawde/log";
+import type { AgentRunResult } from "@clawde/sdk";
+
+const MAX_TELEGRAM_LEN = 4096;
+
+function readBotToken(): string | null {
+  const env = process.env as Record<string, string | undefined>;
+  return (
+    env["CLAWDE_TELEGRAM_BOT_TOKEN"] ??
+    env["clawde-telegram-bot-token"] ??
+    null
+  );
+}
+
+export async function sendTelegramReply(
+  task: Task,
+  agentResult: AgentRunResult,
+  logger: Logger,
+): Promise<void> {
+  if (task.source !== "telegram") return;
+
+  const token = readBotToken();
+  if (token === null) {
+    logger.warn("telegram reply skipped: no bot token", { taskId: task.id });
+    return;
+  }
+
+  const chatId = task.sourceMetadata["chat_id"];
+  if (typeof chatId !== "number") {
+    logger.warn("telegram reply skipped: no chat_id in metadata", { taskId: task.id });
+    return;
+  }
+
+  const text = agentResult.finalText.trim();
+  if (text.length === 0) {
+    logger.warn("telegram reply skipped: empty result", { taskId: task.id });
+    return;
+  }
+
+  const truncated =
+    text.length > MAX_TELEGRAM_LEN ? text.slice(0, MAX_TELEGRAM_LEN - 3) + "..." : text;
+
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: truncated }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      logger.warn("telegram reply failed", {
+        taskId: task.id,
+        status: response.status,
+        body,
+      });
+    } else {
+      logger.info("telegram reply sent", { taskId: task.id, chat_id: chatId });
+    }
+  } catch (err) {
+    logger.warn("telegram reply error", {
+      taskId: task.id,
+      error: (err as Error).message,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- **Novo módulo** `src/worker/telegram-reply.ts`: após cada task com `source=telegram` completar com sucesso, envia o resultado de volta ao remetente via `POST /sendMessage` na Bot API. Best-effort — erros logam WARN sem crashar o worker.
- **`runProcessLoop`** aceita callback `onResult` opcional; `bootstrap` passa `sendTelegramReply` como callback.
- **Fix crítico em `parseRawMessage`** (`src/sdk/parser.ts`): `SDKAssistantMessage` do `@anthropic-ai/claude-agent-sdk` tem formato `{type: 'assistant', message: BetaMessage}`. O texto estava em `message.content` mas o parser nunca desembrulhava esse nível — `finalText` era sempre vazio em **todas** as tasks desde o início. Fix: detectar `type=assistant` com campo `message` objeto e recursir com o `BetaMessage` interno.

## Relacionado
- Fase 5 do roadmap: Telegram full flow
- Fix de bug descoberto durante validação: issue #45 (comportamentos validados)

## Test plan
- [ ] Enviar mensagem no Telegram ao bot
- [ ] Confirmar log `telegram reply sent` no `journalctl --user -u clawde-worker`
- [ ] Confirmar resposta recebida no Telegram
- [ ] Confirmar que tasks CLI (`source=cli`) não disparam reply (early return em `sendTelegramReply`)
- [ ] Confirmar que task com `finalText` vazio loga WARN e não chama API