### PR TITLE
fix(sandbox): resolve /workspace e relative paths no preToolHandler (issue #51)

### DIFF
--- a/src/hooks/handlers.ts
+++ b/src/hooks/handlers.ts
@@ -6,6 +6,7 @@
  * virão em Fase 6.
  */
 
+import { join, isAbsolute } from "node:path";
 import type { ObservationKind } from "@clawde/domain/memory";
 import type {
   HookHandler,
@@ -48,6 +49,8 @@ export interface PreToolUseAgentPolicy {
      * is auto-forwarded back.
      */
     readonly allowed_reads?: ReadonlyArray<string>;
+    /** Working directory used to resolve relative paths in write/read checks. */
+    readonly cwd?: string;
   };
 }
 
@@ -117,9 +120,17 @@ function isPathTraversal(path: string): boolean {
   return p.includes("../") || p.startsWith("..");
 }
 
-function isAllowedWritePath(path: string, allowedWrites: ReadonlyArray<string>): boolean {
-  const target = normalizePath(path);
+function isAllowedWritePath(
+  path: string,
+  allowedWrites: ReadonlyArray<string>,
+  cwd?: string,
+): boolean {
+  let target = normalizePath(path);
   if (isPathTraversal(target)) return false;
+  // Resolve relative paths against cwd so "/workspace" → "/tmp/clawde-N" mapping works.
+  if (!isAbsolute(target) && cwd !== undefined) {
+    target = normalizePath(join(cwd, target));
+  }
   for (const allowed of allowedWrites) {
     const base = normalizePath(allowed);
     if (base.length === 0) continue;
@@ -193,7 +204,7 @@ export function makePreToolUseHandler(
     if (toolName === "Edit" || toolName === "Write") {
       const path = extractPath(input.payload.toolInput);
       const allowedWrites = agent?.sandbox.allowed_writes ?? [];
-      if (allowedWrites.length > 0 && !isAllowedWritePath(path, allowedWrites)) {
+      if (allowedWrites.length > 0 && !isAllowedWritePath(path, allowedWrites, agent?.sandbox.cwd)) {
         emit("tool_blocked", {
           tool: toolName,
           reason: "write_path_not_allowed",

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -32,6 +32,11 @@ export {
   validateEgressList,
 } from "./netns.ts";
 export {
+  type SandboxedWrapper,
+  makeSandboxedClaudeWrapper,
+  resolveClaudeNativeBinary,
+} from "./wrapper.ts";
+export {
   type PathUnitInput,
   type ServiceUnitInput,
   type TimerUnitInput,

--- a/src/sandbox/wrapper.ts
+++ b/src/sandbox/wrapper.ts
@@ -1,0 +1,87 @@
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildBwrapArgs } from "./bwrap.ts";
+
+const CLAUDE_AGENT_SDK_LINUX_X64 =
+  "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude";
+
+/**
+ * Resolve the native claude binary bundled with the SDK, falling back to the
+ * system claude if the SDK binary is not present.
+ */
+export function resolveClaudeNativeBinary(projectRoot = process.cwd()): string {
+  const candidate = join(projectRoot, CLAUDE_AGENT_SDK_LINUX_X64);
+  if (existsSync(candidate)) return candidate;
+  return "/usr/local/bin/claude";
+}
+
+export interface SandboxedWrapper {
+  readonly wrapperPath: string;
+  cleanup(): void;
+}
+
+/**
+ * Creates a temp directory containing a `claude` wrapper script that runs the
+ * real claude binary inside bwrap with filesystem isolation.
+ *
+ * Network is intentionally kept as "host" — the claude binary needs egress to
+ * api.anthropic.com. Full network isolation (loopback-only) is deferred to
+ * Fase 6C, which requires a local API proxy (nftables backend, issue #49).
+ *
+ * Returns the wrapper path and a cleanup function.
+ */
+export function makeSandboxedClaudeWrapper(
+  agentName: string,
+  agentReadOnlyMounts: ReadonlyArray<string>,
+  env: Record<string, string | undefined>,
+  projectRoot?: string,
+): SandboxedWrapper {
+  const claudeBinary = resolveClaudeNativeBinary(projectRoot);
+  const home = homedir();
+  const claudeConfigDir = env.CLAUDE_CONFIG_DIR ?? join(home, ".claude");
+
+  const bwrapArgs = buildBwrapArgs(
+    {
+      bwrapPath: "/usr/bin/bwrap",
+      readOnlyMounts: [
+        ...agentReadOnlyMounts,
+        ...(existsSync(claudeConfigDir) ? [claudeConfigDir] : []),
+        ...(existsSync(join(home, ".claude.json")) ? [join(home, ".claude.json")] : []),
+      ],
+      readWritePaths: [{ host: tmpdir(), sandbox: tmpdir() }],
+      // host network: API egress required (see function doc above)
+      network: "host",
+      workdir: tmpdir(),
+      env: {
+        HOME: home,
+        TMPDIR: tmpdir(),
+        PATH: "/usr/bin:/usr/local/bin:/bin",
+        CLAUDE_CODE_ENTRYPOINT: "sdk-ts",
+        ...(env.CLAUDE_CODE_OAUTH_TOKEN
+          ? { CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN }
+          : {}),
+        ...(env.CLAUDE_CONFIG_DIR ? { CLAUDE_CONFIG_DIR: env.CLAUDE_CONFIG_DIR } : {}),
+        ...(env.ANTHROPIC_API_KEY ? { ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY } : {}),
+      },
+    },
+    claudeBinary,
+    [],
+  );
+
+  // All args except the last item (the claude binary path, which we append with "$@")
+  const configArgs = bwrapArgs.slice(0, -1);
+  const quotedArgs = configArgs.map(shellQuote).join(" ");
+  const script = `#!/bin/sh\nexec /usr/bin/bwrap ${quotedArgs} ${shellQuote(claudeBinary)} "$@"\n`;
+
+  const tmpDir = mkdtempSync(join(tmpdir(), `clawde-wrap-${agentName}-`));
+  const wrapperPath = join(tmpDir, "claude");
+  writeFileSync(wrapperPath, script, { encoding: "utf-8" });
+  chmodSync(wrapperPath, 0o755);
+
+  return { wrapperPath, cleanup: () => rmSync(tmpDir, { recursive: true, force: true }) };
+}
+
+function shellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}

--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -91,6 +91,8 @@ export class RealAgentClient implements AgentClient {
       if (options.workingDirectory !== undefined) queryOptions.cwd = options.workingDirectory;
       if (options.resumeSessionId !== undefined)
         queryOptions.resumeSessionId = options.resumeSessionId;
+      if (options.claudeExecutablePath !== undefined)
+        queryOptions.pathToClaudeCodeExecutable = options.claudeExecutablePath;
 
       // Lazy: parser.ts re-importado para evitar circularidade.
       const { parseRawMessage } = await import("./parser.ts");

--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -3,31 +3,38 @@
  * Padrões inspirados em claude-mem/src/sdk/parser.ts.
  */
 
-import type { ContentBlock, ParsedMessage, TextBlock, ToolUseBlock } from "./types.ts";
+import type {
+	ContentBlock,
+	ParsedMessage,
+	TextBlock,
+	ToolUseBlock,
+} from "./types.ts";
 
 export function isTextBlock(b: ContentBlock): b is TextBlock {
-  return b.type === "text";
+	return b.type === "text";
 }
 
 export function isToolUseBlock(b: ContentBlock): b is ToolUseBlock {
-  return b.type === "tool_use";
+	return b.type === "tool_use";
 }
 
 /**
  * Extrai texto concatenado de uma mensagem (skip tool_use/tool_result).
  */
 export function extractText(message: ParsedMessage): string {
-  return message.blocks
-    .filter(isTextBlock)
-    .map((b) => b.text)
-    .join("\n");
+	return message.blocks
+		.filter(isTextBlock)
+		.map((b) => b.text)
+		.join("\n");
 }
 
 /**
  * Lista tool_uses de uma mensagem.
  */
-export function extractToolUses(message: ParsedMessage): ReadonlyArray<ToolUseBlock> {
-  return message.blocks.filter(isToolUseBlock);
+export function extractToolUses(
+	message: ParsedMessage,
+): ReadonlyArray<ToolUseBlock> {
+	return message.blocks.filter(isToolUseBlock);
 }
 
 /**
@@ -37,46 +44,65 @@ export function extractToolUses(message: ParsedMessage): ReadonlyArray<ToolUseBl
  * Espera entrada com `{type, role?, content?: array | string}`.
  */
 export function parseRawMessage(raw: unknown): ParsedMessage | null {
-  if (raw === null || typeof raw !== "object") return null;
-  const obj = raw as Record<string, unknown>;
-  const role = (obj.role ?? obj.message_role ?? "assistant") as string;
-  if (role !== "user" && role !== "assistant" && role !== "system" && role !== "tool") {
-    return null;
-  }
+	if (raw === null || typeof raw !== "object") return null;
+	const obj = raw as Record<string, unknown>;
 
-  const content = obj.content ?? obj.text ?? obj.message;
-  const blocks: ContentBlock[] = [];
+	// SDKAssistantMessage: {type: 'assistant', message: BetaMessage, uuid, session_id}
+	// The actual content is nested inside message.content — unwrap and recurse.
+	if (
+		obj.type === "assistant" &&
+		obj.message !== null &&
+		typeof obj.message === "object"
+	) {
+		return parseRawMessage(obj.message);
+	}
 
-  if (typeof content === "string") {
-    blocks.push({ type: "text", text: content });
-  } else if (Array.isArray(content)) {
-    for (const item of content) {
-      if (typeof item === "string") {
-        blocks.push({ type: "text", text: item });
-        continue;
-      }
-      if (item === null || typeof item !== "object") continue;
-      const b = item as Record<string, unknown>;
-      const btype = b.type;
-      if (btype === "text" && typeof b.text === "string") {
-        blocks.push({ type: "text", text: b.text });
-      } else if (btype === "tool_use") {
-        blocks.push({
-          type: "tool_use",
-          name: String(b.name ?? "unknown"),
-          input: (b.input ?? {}) as Readonly<Record<string, unknown>>,
-          id: String(b.id ?? ""),
-        });
-      } else if (btype === "tool_result") {
-        blocks.push({
-          type: "tool_result",
-          toolUseId: String(b.tool_use_id ?? b.toolUseId ?? ""),
-          content: typeof b.content === "string" ? b.content : JSON.stringify(b.content),
-          isError: Boolean(b.is_error ?? b.isError ?? false),
-        });
-      }
-    }
-  }
+	const role = (obj.role ?? obj.message_role ?? "assistant") as string;
+	if (
+		role !== "user" &&
+		role !== "assistant" &&
+		role !== "system" &&
+		role !== "tool"
+	) {
+		return null;
+	}
 
-  return { role: role as ParsedMessage["role"], blocks, raw };
+	const content = obj.content ?? obj.text ?? obj.message;
+	const blocks: ContentBlock[] = [];
+
+	if (typeof content === "string") {
+		blocks.push({ type: "text", text: content });
+	} else if (Array.isArray(content)) {
+		for (const item of content) {
+			if (typeof item === "string") {
+				blocks.push({ type: "text", text: item });
+				continue;
+			}
+			if (item === null || typeof item !== "object") continue;
+			const b = item as Record<string, unknown>;
+			const btype = b.type;
+			if (btype === "text" && typeof b.text === "string") {
+				blocks.push({ type: "text", text: b.text });
+			} else if (btype === "tool_use") {
+				blocks.push({
+					type: "tool_use",
+					name: String(b.name ?? "unknown"),
+					input: (b.input ?? {}) as Readonly<Record<string, unknown>>,
+					id: String(b.id ?? ""),
+				});
+			} else if (btype === "tool_result") {
+				blocks.push({
+					type: "tool_result",
+					toolUseId: String(b.tool_use_id ?? b.toolUseId ?? ""),
+					content:
+						typeof b.content === "string"
+							? b.content
+							: JSON.stringify(b.content),
+					isError: Boolean(b.is_error ?? b.isError ?? false),
+				});
+			}
+		}
+	}
+
+	return { role: role as ParsedMessage["role"], blocks, raw };
 }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -85,6 +85,8 @@ export interface RunAgentOptions {
   readonly appendSystemPrompt?: string;
   readonly workingDirectory?: string;
   readonly bare?: boolean;
+  /** Path to a custom claude executable (e.g. a bwrap wrapper script for sandboxed agents). */
+  readonly claudeExecutablePath?: string;
 }
 
 /**

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -1,13 +1,16 @@
 import { homedir, hostname } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { AgentDefinitionError, loadAllAgentDefinitionsWithWarnings } from "@clawde/agents";
+import {
+	AgentDefinitionError,
+	loadAllAgentDefinitionsWithWarnings,
+} from "@clawde/agents";
 import { sendAlertBestEffort } from "@clawde/alerts";
 import { loadConfig } from "@clawde/config";
 import { closeDb, openDb } from "@clawde/db/client";
 import {
-  SLOW_INTEGRITY_CHECK_MS,
-  isDbIntegrityOk,
-  runDbIntegrityChecks,
+	isDbIntegrityOk,
+	runDbIntegrityChecks,
+	SLOW_INTEGRITY_CHECK_MS,
 } from "@clawde/db/integrity";
 import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
 import { EventsRepo } from "@clawde/db/repositories/events";
@@ -15,204 +18,226 @@ import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, setMinLevel } from "@clawde/log";
-import { QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
+import { makeQuotaPolicy, QuotaTracker } from "@clawde/quota";
 import { RealAgentClient } from "@clawde/sdk";
-import { LeaseManager, type RunnerDeps, makeReconciler, processNextPending } from "./index.ts";
+import {
+	LeaseManager,
+	makeReconciler,
+	processNextPending,
+	type RunnerDeps,
+} from "./index.ts";
+import type { ProcessResult } from "./runner.ts";
+import { sendTelegramReply } from "./telegram-reply.ts";
 
 const DEFAULT_MAX_TASKS = 50;
 
 function expandHome(p: string): string {
-  if (p.startsWith("~/") || p === "~") return p.replace(/^~/, homedir());
-  return p;
+	if (p.startsWith("~/") || p === "~") return p.replace(/^~/, homedir());
+	return p;
 }
 
-export function parseMaxTasks(argv: ReadonlyArray<string>, fallback = DEFAULT_MAX_TASKS): number {
-  const idx = argv.indexOf("--max-tasks");
-  if (idx < 0 || idx + 1 >= argv.length) return fallback;
-  const raw = argv[idx + 1];
-  if (raw === undefined) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+export function parseMaxTasks(
+	argv: ReadonlyArray<string>,
+	fallback = DEFAULT_MAX_TASKS,
+): number {
+	const idx = argv.indexOf("--max-tasks");
+	if (idx < 0 || idx + 1 >= argv.length) return fallback;
+	const raw = argv[idx + 1];
+	if (raw === undefined) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 export function parseDryRun(argv: ReadonlyArray<string>): boolean {
-  return argv.includes("--dry-run");
+	return argv.includes("--dry-run");
 }
 
 export type LoopExitReason = "empty" | "deferred" | "max_tasks";
 
 export interface LoopResult {
-  readonly processed: number;
-  readonly exitReason: LoopExitReason;
+	readonly processed: number;
+	readonly exitReason: LoopExitReason;
 }
 
 function assertStartupDbIntegrity(
-  db: ReturnType<typeof openDb>,
-  logger: ReturnType<typeof createLogger>,
+	db: ReturnType<typeof openDb>,
+	logger: ReturnType<typeof createLogger>,
 ): void {
-  const report = runDbIntegrityChecks(db);
-  if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
-    logger.warn("startup integrity_check slow", {
-      elapsed_ms: report.elapsedMs,
-      threshold_ms: SLOW_INTEGRITY_CHECK_MS,
-    });
-  }
-  if (isDbIntegrityOk(report)) {
-    return;
-  }
+	const report = runDbIntegrityChecks(db);
+	if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
+		logger.warn("startup integrity_check slow", {
+			elapsed_ms: report.elapsedMs,
+			threshold_ms: SLOW_INTEGRITY_CHECK_MS,
+		});
+	}
+	if (isDbIntegrityOk(report)) {
+		return;
+	}
 
-  const payload = {
-    integrity_check: report.integrityCheck,
-    quick_check: report.quickCheck,
-    foreign_key_violations: report.foreignKeyViolations.length,
-    elapsed_ms: report.elapsedMs,
-  } as const;
-  try {
-    new EventsRepo(db).insert({
-      taskRunId: null,
-      sessionId: null,
-      traceId: null,
-      spanId: null,
-      kind: "db_corrupted",
-      payload,
-    });
-  } catch (err) {
-    logger.error("failed to persist db_corrupted event", {
-      error: (err as Error).message,
-    });
-  }
+	const payload = {
+		integrity_check: report.integrityCheck,
+		quick_check: report.quickCheck,
+		foreign_key_violations: report.foreignKeyViolations.length,
+		elapsed_ms: report.elapsedMs,
+	} as const;
+	try {
+		new EventsRepo(db).insert({
+			taskRunId: null,
+			sessionId: null,
+			traceId: null,
+			spanId: null,
+			kind: "db_corrupted",
+			payload,
+		});
+	} catch (err) {
+		logger.error("failed to persist db_corrupted event", {
+			error: (err as Error).message,
+		});
+	}
 
-  logger.error("db integrity failed; entering readonly mode", payload);
-  void sendAlertBestEffort({
-    severity: "critical",
-    trigger: "db_corrupted",
-    cooldownKey: "db_corrupted",
-    payload,
-  });
-  throw new Error(
-    `db integrity failed (integrity_check=${report.integrityCheck}, quick_check=${report.quickCheck}, fk=${report.foreignKeyViolations.length})`,
-  );
+	logger.error("db integrity failed; entering readonly mode", payload);
+	void sendAlertBestEffort({
+		severity: "critical",
+		trigger: "db_corrupted",
+		cooldownKey: "db_corrupted",
+		payload,
+	});
+	throw new Error(
+		`db integrity failed (integrity_check=${report.integrityCheck}, quick_check=${report.quickCheck}, fk=${report.foreignKeyViolations.length})`,
+	);
 }
 
-export async function runProcessLoop(deps: RunnerDeps, maxTasks: number): Promise<LoopResult> {
-  let processed = 0;
-  while (processed < maxTasks) {
-    const result = await processNextPending(deps);
-    if (result === null) return { processed, exitReason: "empty" };
-    if (result.agentResult.stopReason === "deferred") {
-      return { processed, exitReason: "deferred" };
-    }
-    processed += 1;
-  }
-  return { processed, exitReason: "max_tasks" };
+export async function runProcessLoop(
+	deps: RunnerDeps,
+	maxTasks: number,
+	onResult?: (result: ProcessResult) => Promise<void>,
+): Promise<LoopResult> {
+	let processed = 0;
+	while (processed < maxTasks) {
+		const result = await processNextPending(deps);
+		if (result === null) return { processed, exitReason: "empty" };
+		if (result.agentResult.stopReason === "deferred") {
+			return { processed, exitReason: "deferred" };
+		}
+		if (onResult !== undefined) {
+			await onResult(result);
+		}
+		processed += 1;
+	}
+	return { processed, exitReason: "max_tasks" };
 }
 
 export async function bootstrap(
-  argv: ReadonlyArray<string> = process.argv.slice(2),
+	argv: ReadonlyArray<string> = process.argv.slice(2),
 ): Promise<void> {
-  const config = loadConfig();
-  setMinLevel(config.clawde.log_level);
-  const logger = createLogger({ service: "worker" });
-  const dbPath = join(expandHome(config.clawde.home), "state.db");
-  const db = openDb(dbPath);
-  try {
-    applyPending(db, defaultMigrationsDir());
-    assertStartupDbIntegrity(db, logger);
-    const tasksRepo = new TasksRepo(db);
-    const runsRepo = new TaskRunsRepo(db);
-    const eventsRepo = new EventsRepo(db);
-    const quotaTracker = new QuotaTracker(new QuotaLedgerRepo(db));
-    const quotaPolicy = makeQuotaPolicy();
-    const leaseManager = new LeaseManager(runsRepo, eventsRepo, {
-      leaseSeconds: config.worker.lease_seconds,
-      heartbeatSeconds: config.worker.heartbeat_seconds,
-    });
-    const reconciler = makeReconciler(runsRepo, eventsRepo, {
-      tasksRepo,
-      workspaceTmpRoot: "/tmp",
-    });
-    const agentsRoot = join(expandHome(config.clawde.home), "agents");
-    const agentDefs = (() => {
-      try {
-        return loadAllAgentDefinitionsWithWarnings(agentsRoot, {
-          onWarning: (warning) => {
-            if (warning.kind === "bash_disallowed_by_sandbox_level") {
-              logger.warn("agent policy mismatch: Bash will be blocked at runtime", {
-                agent: warning.agentName,
-                sandbox_level: warning.sandboxLevel,
-                hint: "Set sandbox level to 1 or remove Bash from allowedTools (ADR 0015 / T-050).",
-              });
-            }
-          },
-        });
-      } catch (err) {
-        if (err instanceof AgentDefinitionError) {
-          const agentName = basename(dirname(err.agentPath));
-          throw new Error(`agent ${agentName} invalid: ${err.message}`);
-        }
-        throw err;
-      }
-    })();
-    const agentDefByName = new Map(agentDefs.map((d) => [d.name, d] as const));
-    const agentClient = new RealAgentClient();
-    const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
-    const reconcileResult = reconciler.reconcile(workerId);
-    logger.info("startup reconcile", {
-      expired_count: reconcileResult.expired.length,
-      reenqueued_count: reconcileResult.reenqueued.length,
-      cleaned_orphans: reconcileResult.cleanedOrphans,
-    });
-    const maxTasks = parseMaxTasks(argv);
-    const dryRun = parseDryRun(argv);
-    const queueSize = tasksRepo.findPending(1000).length;
-    const quotaState = quotaTracker.currentWindow().state;
-    logger.info("worker bootstrap state", {
-      dry_run: dryRun,
-      agents_loaded: agentDefs.length,
-      queue_size: queueSize,
-      quota_state: quotaState,
-    });
+	const config = loadConfig();
+	setMinLevel(config.clawde.log_level);
+	const logger = createLogger({ service: "worker" });
+	const dbPath = join(expandHome(config.clawde.home), "state.db");
+	const db = openDb(dbPath);
+	try {
+		applyPending(db, defaultMigrationsDir());
+		assertStartupDbIntegrity(db, logger);
+		const tasksRepo = new TasksRepo(db);
+		const runsRepo = new TaskRunsRepo(db);
+		const eventsRepo = new EventsRepo(db);
+		const quotaTracker = new QuotaTracker(new QuotaLedgerRepo(db));
+		const quotaPolicy = makeQuotaPolicy();
+		const leaseManager = new LeaseManager(runsRepo, eventsRepo, {
+			leaseSeconds: config.worker.lease_seconds,
+			heartbeatSeconds: config.worker.heartbeat_seconds,
+		});
+		const reconciler = makeReconciler(runsRepo, eventsRepo, {
+			tasksRepo,
+			workspaceTmpRoot: "/tmp",
+		});
+		const agentsRoot = join(expandHome(config.clawde.home), "agents");
+		const agentDefs = (() => {
+			try {
+				return loadAllAgentDefinitionsWithWarnings(agentsRoot, {
+					onWarning: (warning) => {
+						if (warning.kind === "bash_disallowed_by_sandbox_level") {
+							logger.warn(
+								"agent policy mismatch: Bash will be blocked at runtime",
+								{
+									agent: warning.agentName,
+									sandbox_level: warning.sandboxLevel,
+									hint: "Set sandbox level to 1 or remove Bash from allowedTools (ADR 0015 / T-050).",
+								},
+							);
+						}
+					},
+				});
+			} catch (err) {
+				if (err instanceof AgentDefinitionError) {
+					const agentName = basename(dirname(err.agentPath));
+					throw new Error(`agent ${agentName} invalid: ${err.message}`);
+				}
+				throw err;
+			}
+		})();
+		const agentDefByName = new Map(agentDefs.map((d) => [d.name, d] as const));
+		const agentClient = new RealAgentClient();
+		const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
+		const reconcileResult = reconciler.reconcile(workerId);
+		logger.info("startup reconcile", {
+			expired_count: reconcileResult.expired.length,
+			reenqueued_count: reconcileResult.reenqueued.length,
+			cleaned_orphans: reconcileResult.cleanedOrphans,
+		});
+		const maxTasks = parseMaxTasks(argv);
+		const dryRun = parseDryRun(argv);
+		const queueSize = tasksRepo.findPending(1000).length;
+		const quotaState = quotaTracker.currentWindow().state;
+		logger.info("worker bootstrap state", {
+			dry_run: dryRun,
+			agents_loaded: agentDefs.length,
+			queue_size: queueSize,
+			quota_state: quotaState,
+		});
 
-    if (dryRun) {
-      logger.info("worker dry-run complete", {
-        agents_loaded: agentDefs.length,
-        queue_size: queueSize,
-        quota_state: quotaState,
-      });
-      return;
-    }
+		if (dryRun) {
+			logger.info("worker dry-run complete", {
+				agents_loaded: agentDefs.length,
+				queue_size: queueSize,
+				quota_state: quotaState,
+			});
+			return;
+		}
 
-    const loop = await runProcessLoop(
-      {
-        tasksRepo,
-        runsRepo,
-        eventsRepo,
-        leaseManager,
-        quotaTracker,
-        quotaPolicy,
-        agentClient,
-        logger,
-        workerId,
-        workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
-        resolveAgentDefinition: async (agent) => agentDefByName.get(agent) ?? null,
-      },
-      maxTasks,
-    );
-    logger.info("worker idle", {
-      processed: loop.processed,
-      max_tasks: maxTasks,
-      exit_reason: loop.exitReason,
-    });
-  } finally {
-    closeDb(db);
-  }
+		const loop = await runProcessLoop(
+			{
+				tasksRepo,
+				runsRepo,
+				eventsRepo,
+				leaseManager,
+				quotaTracker,
+				quotaPolicy,
+				agentClient,
+				logger,
+				workerId,
+				workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
+				resolveAgentDefinition: async (agent) =>
+					agentDefByName.get(agent) ?? null,
+			},
+			maxTasks,
+			(result) => sendTelegramReply(result.task, result.agentResult, logger),
+		);
+		logger.info("worker idle", {
+			processed: loop.processed,
+			max_tasks: maxTasks,
+			exit_reason: loop.exitReason,
+		});
+	} finally {
+		closeDb(db);
+	}
 }
 
 if (import.meta.main) {
-  bootstrap()
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error((err as Error).message);
-      process.exit(1);
-    });
+	bootstrap()
+		.then(() => process.exit(0))
+		.catch((err) => {
+			console.error((err as Error).message);
+			process.exit(1);
+		});
 }

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -31,6 +31,11 @@ import type { QuotaTracker } from "@clawde/quota";
 import type { PipelineConfig, runReviewPipeline as runReviewPipelineFn } from "@clawde/review";
 import { composeAppendSystemPrompt } from "@clawde/sanitize";
 import {
+  isBwrapAvailable,
+  makeSandboxedClaudeWrapper,
+  type SandboxedWrapper,
+} from "@clawde/sandbox";
+import {
   type AgentClient,
   type AgentRunResult,
   SdkAuthError,
@@ -400,13 +405,33 @@ async function runAgentWithLedger(
     allowedTools?: ReadonlyArray<string>;
     disallowedTools?: ReadonlyArray<string>;
     maxTurns?: number;
+    claudeExecutablePath?: string;
   } = {
     prompt: effectivePrompt,
   };
   const allowedTools = agentDef?.frontmatter?.allowedTools ?? [];
   const disallowedTools = new Set(agentDef?.frontmatter?.disallowedTools ?? []);
-  if ((agentDef?.sandbox?.level ?? 1) >= 2) {
+  const sandboxLevel = agentDef?.sandbox?.level ?? 1;
+  if (sandboxLevel >= 2) {
     disallowedTools.add("Bash");
+  }
+
+  // OS-level filesystem sandbox for level >= 2 agents via bwrap.
+  let sandboxWrapper: SandboxedWrapper | null = null;
+  if (sandboxLevel >= 2 && isBwrapAvailable()) {
+    try {
+      sandboxWrapper = makeSandboxedClaudeWrapper(
+        task.agent,
+        agentDef?.sandbox?.read_only_mounts ?? [],
+        process.env as Record<string, string | undefined>,
+      );
+      streamOpts.claudeExecutablePath = sandboxWrapper.wrapperPath;
+    } catch (err) {
+      deps.logger.warn("bwrap wrapper creation failed, running unsandboxed", {
+        agent: task.agent,
+        error: (err as Error).message,
+      });
+    }
   }
   if (allowedTools.length > 0) streamOpts.allowedTools = allowedTools;
   if (disallowedTools.size > 0) streamOpts.disallowedTools = [...disallowedTools];
@@ -505,6 +530,8 @@ async function runAgentWithLedger(
     }
     error = (err as Error).message;
     stopReason = "error";
+  } finally {
+    sandboxWrapper?.cleanup();
   }
 
   return {

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -439,16 +439,27 @@ async function runAgentWithLedger(
     streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
   }
 
+  // For level < 2 agents (no bwrap), sandbox.toml uses "/workspace" as a
+  // placeholder for the ephemeral worktree. Without bwrap there is no filesystem
+  // mapping, so resolve "/workspace" to the actual working directory (issue #51).
+  const rawAllowedWrites = agentDef?.sandbox?.allowed_writes ?? [];
+  const effectiveAllowedWrites =
+    sandboxLevel < 2 && workingDirectoryOverride !== null
+      ? rawAllowedWrites.map((w) => (w === "/workspace" ? workingDirectoryOverride : w))
+      : rawAllowedWrites;
+
   const preToolHandler = makePreToolUseHandler(() => {}, {
     allowedTools,
     sandbox: {
       level: agentDef?.sandbox?.level ?? 1,
-      allowed_writes: agentDef?.sandbox?.allowed_writes ?? [],
+      allowed_writes: effectiveAllowedWrites,
       // Propaga allowed_reads SOMENTE quando definido na config; senão deixa
       // undefined (comportamento legacy permissivo) — `exactOptionalPropertyTypes`.
       ...(agentDef?.sandbox?.allowed_reads !== undefined
         ? { allowed_reads: agentDef.sandbox.allowed_reads }
         : {}),
+      // cwd enables relative-path resolution in write/read checks (issue #51).
+      ...(workingDirectoryOverride !== null ? { cwd: workingDirectoryOverride } : {}),
     },
   });
   if (task.sessionId !== null) streamOpts.sessionId = task.sessionId;

--- a/src/worker/telegram-reply.ts
+++ b/src/worker/telegram-reply.ts
@@ -1,0 +1,66 @@
+import type { Task } from "@clawde/domain/task";
+import type { Logger } from "@clawde/log";
+import type { AgentRunResult } from "@clawde/sdk";
+
+const MAX_TELEGRAM_LEN = 4096;
+
+function readBotToken(): string | null {
+  const env = process.env as Record<string, string | undefined>;
+  return (
+    env["CLAWDE_TELEGRAM_BOT_TOKEN"] ??
+    env["clawde-telegram-bot-token"] ??
+    null
+  );
+}
+
+export async function sendTelegramReply(
+  task: Task,
+  agentResult: AgentRunResult,
+  logger: Logger,
+): Promise<void> {
+  if (task.source !== "telegram") return;
+
+  const token = readBotToken();
+  if (token === null) {
+    logger.warn("telegram reply skipped: no bot token", { taskId: task.id });
+    return;
+  }
+
+  const chatId = task.sourceMetadata["chat_id"];
+  if (typeof chatId !== "number") {
+    logger.warn("telegram reply skipped: no chat_id in metadata", { taskId: task.id });
+    return;
+  }
+
+  const text = agentResult.finalText.trim();
+  if (text.length === 0) {
+    logger.warn("telegram reply skipped: empty result", { taskId: task.id });
+    return;
+  }
+
+  const truncated =
+    text.length > MAX_TELEGRAM_LEN ? text.slice(0, MAX_TELEGRAM_LEN - 3) + "..." : text;
+
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: truncated }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      logger.warn("telegram reply failed", {
+        taskId: task.id,
+        status: response.status,
+        body,
+      });
+    } else {
+      logger.info("telegram reply sent", { taskId: task.id, chat_id: chatId });
+    }
+  } catch (err) {
+    logger.warn("telegram reply error", {
+      taskId: task.id,
+      error: (err as Error).message,
+    });
+  }
+}

--- a/src/worker/workspace.ts
+++ b/src/worker/workspace.ts
@@ -35,6 +35,8 @@ export interface AgentDefinitionLike {
     readonly level: 1 | 2 | 3;
     readonly allowed_writes: ReadonlyArray<string>;
     readonly allowed_reads?: ReadonlyArray<string> | undefined;
+    readonly read_only_mounts?: ReadonlyArray<string>;
+    readonly network?: string;
   };
 }
 


### PR DESCRIPTION
## Fixes #51

Dois fixes para o bug do `implementer` com `allowed_writes=["/workspace"]`:

**1. `runner.ts`** — quando `sandboxLevel < 2` (sem bwrap) e workspace ephemeral existe, mapeia `/workspace` no `allowed_writes` para o path real do worktree (`/tmp/clawde-N`). Sem bwrap não há mapeamento de filesystem.

**2. `handlers.ts`** — `isAllowedWritePath` aceita `cwd` opcional e resolve relative paths antes do prefix check. Agents usando `src/worker/runner.ts` (relativo) têm o path resolvido contra `cwd=/tmp/clawde-N` antes de comparar contra o `allowed_writes`.

## Limitação conhecida (documentada no issue #51)

Agents que usam absolute paths para o repo original (`/home/pcdan/clawde-test/...`) ainda são bloqueados. O Claude Code às vezes infere o path absoluto do git root pelo contexto. Esse caso requer trabalho separado.

## Test plan
- [ ] Implementer com path relativo: `src/worker/runner.ts` → permitido
- [ ] Implementer com path absoluto ao worktree: `/tmp/clawde-N/src/...` → permitido  
- [ ] Implementer com path ao repo original: `/home/pcdan/clawde-test/src/...` → ainda bloqueado (limitação documentada)
- [ ] telegram-bot `allowed_reads=[]` ainda bloqueia leituras