### PR TITLE
fix(worker): runtime SDK binary resolution (#41 #43 #47)

### DIFF
--- a/config/clawde.toml.example
+++ b/config/clawde.toml.example
@@ -11,6 +11,12 @@ log_level = "INFO"   # TRACE | DEBUG | INFO | WARN | ERROR | FATAL
 [worker]
 max_parallel            = 1                          # 1 worker por vez (Max evita serial cost)
 cli_path                = "/usr/local/bin/claude"
+# Opcional: caminho explícito para o binário do Claude Code usado pelo SDK.
+# Útil quando o worker roda fora do diretório do projeto ou em WSL2/systemd
+# sem acesso ao PATH do shell interativo. Configure automaticamente com:
+#   bash scripts/setup-linux.sh
+# Docs: docs/DEPLOY-LINUX.md
+# claude_executable_path = "~/.clawde/bin/claude"
 cli_min_version         = "2.0.0"
 default_max_turns       = 15
 default_timeout_seconds = 1800                        # 30min hard cap por task

--- a/docs/DEPLOY-LINUX.md
+++ b/docs/DEPLOY-LINUX.md
@@ -1,0 +1,75 @@
+# Clawde — Deploy Linux
+
+## Pre-requisites
+
+- Ubuntu 22.04+ ou outra distro Linux com systemd user
+- Bun instalado e funcional no shell do usuário
+- repo do Clawde disponível localmente
+- Claude Code SDK instalado nas dependências do projeto
+
+## SDK binary setup
+
+Quando o worker roda via systemd ou a partir de bundle fora do diretório do
+projeto, o SDK pode não conseguir resolver o binário certo sozinho.
+
+Execute:
+
+```bash
+bash scripts/setup-linux.sh
+```
+
+O script:
+
+1. detecta `glibc` vs `musl`
+2. procura um binário Linux x64 compatível do Claude
+3. instala `~/.clawde/bin/claude` como symlink
+4. adiciona `worker.claude_executable_path` em `~/.clawde/config/clawde.toml`
+   quando o campo ainda não existe
+
+## Systemd deploy
+
+Depois do setup do binário:
+
+```bash
+bun run build
+systemctl --user daemon-reload
+systemctl --user enable --now clawde-receiver.service
+systemctl --user enable --now clawde-worker.path
+```
+
+Se você usa timers complementares, habilite também os timers relevantes.
+
+## Smoke test
+
+Depois do deploy:
+
+```bash
+clawde diagnose all --output text
+```
+
+Para checar só o worker:
+
+```bash
+systemctl --user start clawde-worker.service
+systemctl --user status clawde-worker.service
+```
+
+## Known issues
+
+### `#41` musl vs glibc
+
+Em Ubuntu/Debian, o worker pode falhar se o SDK resolver um binário `musl`
+incompatível. O `setup-linux.sh` tenta preferir um binário Linux x64 compatível
+com o ambiente atual.
+
+### `#43` bundle fora do diretório do projeto
+
+Quando `worker-main.js` roda em `~/.clawde/dist/`, a resolução relativa ao
+`node_modules` do projeto pode não funcionar. Nesse caso,
+`worker.claude_executable_path` é o caminho suportado.
+
+### `#47` `claude not found` em WSL2
+
+Se o `claude` só existir via npm do Windows, o systemd user do WSL2 normalmente
+não enxerga `/mnt/c/...` no PATH. O setup Linux precisa apontar para um binário
+realmente acessível do lado Linux.

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -42,11 +42,62 @@ CONFIG_PATH="${HOME}/.clawde/config/clawde.toml"
 if [[ ! -f "${CONFIG_PATH}" ]]; then
   touch "${CONFIG_PATH}"
 fi
-if ! grep -q 'claude_executable_path' "${CONFIG_PATH}" 2>/dev/null; then
-  {
-    printf '\n[worker]\n'
-    printf 'claude_executable_path = "%s"\n' "${HOME}/.clawde/bin/claude"
-  } >> "${CONFIG_PATH}"
+
+worker_key_line="claude_executable_path = \"${HOME}/.clawde/bin/claude\""
+
+has_uncommented_key() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*claude_executable_path[[:space:]]*=/ { found=1 }
+    END { exit found ? 0 : 1 }
+  ' "${CONFIG_PATH}"
+}
+
+has_worker_section() {
+  awk '
+    /^[[:space:]]*\[worker\][[:space:]]*$/ { found=1 }
+    END { exit found ? 0 : 1 }
+  ' "${CONFIG_PATH}"
+}
+
+insert_into_worker_section() {
+  local tmp
+  tmp="$(mktemp)"
+  awk -v line="${worker_key_line}" '
+    BEGIN {
+      in_worker = 0
+      inserted = 0
+    }
+    /^[[:space:]]*\[/ {
+      if (in_worker && !inserted) {
+        print line
+        inserted = 1
+      }
+      in_worker = ($0 ~ /^[[:space:]]*\[worker\][[:space:]]*$/)
+      print
+      next
+    }
+    {
+      print
+    }
+    END {
+      if (in_worker && !inserted) {
+        print line
+      }
+    }
+  ' "${CONFIG_PATH}" > "${tmp}"
+  mv "${tmp}" "${CONFIG_PATH}"
+}
+
+if ! has_uncommented_key; then
+  if has_worker_section; then
+    insert_into_worker_section
+  else
+    {
+      printf '\n[worker]\n'
+      printf '%s\n' "${worker_key_line}"
+    } >> "${CONFIG_PATH}"
+  fi
 fi
 
 echo "setup-linux.sh: OK — claude binary at ${HOME}/.clawde/bin/claude"

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LIBC="glibc"
+if ldd --version 2>&1 | grep -qi musl; then
+  LIBC="musl"
+fi
+
+find_sdk_binary() {
+  local pkg=""
+  if [[ "$LIBC" == "musl" ]]; then
+    pkg="@anthropic-ai/claude-agent-sdk-linux-x64-musl"
+  else
+    pkg="@anthropic-ai/claude-agent-sdk-linux-x64"
+  fi
+
+  bun -e "import { createRequire } from 'node:module'; const require = createRequire(process.cwd() + '/'); console.log(require.resolve('${pkg}/claude'));" 2>/dev/null || true
+}
+
+find_fallback_binary() {
+  find "${HOME}/.bun" "${HOME}/.npm" "${HOME}/.local" \
+    \( -path '*linux-x64/claude' -o -path '*linux-x64-musl/claude' \) 2>/dev/null |
+    head -n 1 || true
+}
+
+CLAUDE_BIN="$(find_sdk_binary)"
+if [[ -z "${CLAUDE_BIN}" ]]; then
+  CLAUDE_BIN="$(find_fallback_binary)"
+fi
+if [[ -z "${CLAUDE_BIN}" ]]; then
+  CLAUDE_BIN="$(which claude 2>/dev/null || true)"
+fi
+if [[ -z "${CLAUDE_BIN}" ]]; then
+  echo "setup-linux.sh: ERROR — claude binary not found. Install via native installer." >&2
+  exit 1
+fi
+
+mkdir -p "${HOME}/.clawde/bin" "${HOME}/.clawde/config"
+ln -sf "${CLAUDE_BIN}" "${HOME}/.clawde/bin/claude"
+
+CONFIG_PATH="${HOME}/.clawde/config/clawde.toml"
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+  touch "${CONFIG_PATH}"
+fi
+if ! grep -q 'claude_executable_path' "${CONFIG_PATH}" 2>/dev/null; then
+  {
+    printf '\n[worker]\n'
+    printf 'claude_executable_path = "%s"\n' "${HOME}/.clawde/bin/claude"
+  } >> "${CONFIG_PATH}"
+fi
+
+echo "setup-linux.sh: OK — claude binary at ${HOME}/.clawde/bin/claude"

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -19,6 +19,7 @@ export const ClawdeBaseSchema = z.object({
 export const WorkerSchema = z.object({
   max_parallel: z.number().int().positive().default(1),
   cli_path: z.string().default("/usr/local/bin/claude"),
+  claude_executable_path: z.string().optional(),
   cli_min_version: z.string().default("2.0.0"),
   default_max_turns: z.number().int().positive().default(15),
   default_timeout_seconds: z.number().int().positive().default(1800),

--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -17,6 +17,10 @@ import { SdkAuthError as SdkAuthErrorClass } from "./types.ts";
 import { SdkNetworkError as SdkNetworkErrorClass } from "./types.ts";
 import { SdkRateLimitError as SdkRateLimitErrorClass } from "./types.ts";
 
+export interface RealAgentClientOptions {
+  readonly pathToClaudeCodeExecutable?: string;
+}
+
 export function mapSdkError(err: unknown): Error {
   const base = err instanceof Error ? err : new Error(String(err));
   const msg = base.message.toLowerCase();
@@ -75,6 +79,8 @@ export async function collectRun(stream: AsyncIterable<ParsedMessage>): Promise<
  * carregar o SDK em comandos que não invocam Claude (ex: `clawde quota status`).
  */
 export class RealAgentClient implements AgentClient {
+  constructor(private readonly defaults: RealAgentClientOptions = {}) {}
+
   async *stream(options: RunAgentOptions): AsyncIterable<ParsedMessage> {
     try {
       const sdk = await import("@anthropic-ai/claude-agent-sdk");
@@ -89,6 +95,11 @@ export class RealAgentClient implements AgentClient {
         queryOptions.appendSystemPrompt = options.appendSystemPrompt;
       }
       if (options.workingDirectory !== undefined) queryOptions.cwd = options.workingDirectory;
+      if (options.pathToClaudeCodeExecutable !== undefined) {
+        queryOptions.pathToClaudeCodeExecutable = options.pathToClaudeCodeExecutable;
+      } else if (this.defaults.pathToClaudeCodeExecutable !== undefined) {
+        queryOptions.pathToClaudeCodeExecutable = this.defaults.pathToClaudeCodeExecutable;
+      }
       if (options.resumeSessionId !== undefined)
         queryOptions.resumeSessionId = options.resumeSessionId;
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -84,6 +84,7 @@ export interface RunAgentOptions {
   readonly maxTurns?: number;
   readonly appendSystemPrompt?: string;
   readonly workingDirectory?: string;
+  readonly pathToClaudeCodeExecutable?: string;
   readonly bare?: boolean;
 }
 

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -26,6 +26,11 @@ function expandHome(p: string): string {
   return p;
 }
 
+export function resolveClaudeExecutablePath(configPath: string | undefined): string | undefined {
+  if (configPath === undefined || configPath.trim().length === 0) return undefined;
+  return expandHome(configPath);
+}
+
 export function parseMaxTasks(argv: ReadonlyArray<string>, fallback = DEFAULT_MAX_TASKS): number {
   const idx = argv.indexOf("--max-tasks");
   if (idx < 0 || idx + 1 >= argv.length) return fallback;
@@ -154,7 +159,12 @@ export async function bootstrap(
       }
     })();
     const agentDefByName = new Map(agentDefs.map((d) => [d.name, d] as const));
-    const agentClient = new RealAgentClient();
+    const claudeExecutablePath = resolveClaudeExecutablePath(config.worker.claude_executable_path);
+    const agentClient = new RealAgentClient(
+      claudeExecutablePath === undefined
+        ? {}
+        : { pathToClaudeCodeExecutable: claudeExecutablePath },
+    );
     const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
     const reconcileResult = reconciler.reconcile(workerId);
     logger.info("startup reconcile", {

--- a/tests/integration/worker-bootstrap.test.ts
+++ b/tests/integration/worker-bootstrap.test.ts
@@ -89,6 +89,49 @@ describe("worker bootstrap integration", () => {
   );
 
   test(
+    "exits 0 in dry-run when worker.claude_executable_path is configured",
+    async () => {
+      if (!existsSync(DIST)) return;
+
+      const dir = mkdtempSync(join(tmpdir(), "clawde-worker-boot-path-"));
+      const dbPath = join(dir, "state.db");
+      const configPath = join(dir, "clawde.toml");
+      writeFileSync(
+        configPath,
+        `[clawde]\nhome = "${dir}"\nlog_level = "ERROR"\n\n[worker]\nclaude_executable_path = "/bin/true"\n`,
+      );
+
+      const preDb = openDb(dbPath);
+      applyPending(preDb, MIGRATIONS_DIR);
+      closeDb(preDb);
+
+      const proc = Bun.spawn([BUN_BIN, "run", DIST, "--dry-run"], {
+        env: { ...process.env, CLAWDE_CONFIG: configPath },
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+
+      cleanups.push(() => {
+        try {
+          proc.kill();
+        } catch {}
+        rmSync(dir, { recursive: true, force: true });
+      });
+
+      const exitCode = await Promise.race([
+        proc.exited,
+        Bun.sleep(5000).then(() => {
+          proc.kill();
+          return -1 as number;
+        }),
+      ]);
+
+      expect(exitCode).toBe(0);
+    },
+    { timeout: 8_000 },
+  );
+
+  test(
     "exits 1 + emits db_corrupted when startup integrity check finds FK diff",
     async () => {
       if (!existsSync(DIST)) return;

--- a/tests/unit/config/load.test.ts
+++ b/tests/unit/config/load.test.ts
@@ -87,6 +87,19 @@ max_age_minutes = 45
     expect(cfg.replica?.max_age_minutes).toBe(45);
   });
 
+  test("worker.claude_executable_path é aceito quando presente", () => {
+    writeFileSync(
+      path,
+      `
+[worker]
+claude_executable_path = "/home/test/.clawde/bin/claude"
+`,
+    );
+
+    const cfg = loadConfig({ path, env: {} });
+    expect(cfg.worker.claude_executable_path).toBe("/home/test/.clawde/bin/claude");
+  });
+
   test("valor inválido lança ConfigError com path", () => {
     writeFileSync(
       path,

--- a/tests/unit/sandbox/systemd.test.ts
+++ b/tests/unit/sandbox/systemd.test.ts
@@ -179,6 +179,11 @@ describe("deploy/systemd unit files reais", () => {
     expect(statSync(prunePath).mode & 0o111).toBeGreaterThan(0);
   });
 
+  test("setup-linux script tem exec bit", () => {
+    const scriptPath = join(import.meta.dirname, "../../../scripts/setup-linux.sh");
+    expect(statSync(scriptPath).mode & 0o111).toBeGreaterThan(0);
+  });
+
   test("clawde-restore-drill.timer roda mensal dia 1 às 04:30", () => {
     const content = readUnit("clawde-restore-drill.timer");
     expect(content).toContain("OnCalendar=*-*-01 04:30:00");

--- a/tests/unit/scripts/setup-linux.test.ts
+++ b/tests/unit/scripts/setup-linux.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dirname, "../../..");
+const SCRIPT_PATH = join(REPO_ROOT, "scripts/setup-linux.sh");
+
+interface ScriptRunResult {
+  readonly exitCode: number;
+  readonly configPath: string;
+  readonly configText: string;
+}
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+function runSetupLinux(initialConfig: string): ScriptRunResult {
+  const root = mkdtempSync(join(tmpdir(), "clawde-setup-linux-"));
+  const home = join(root, "home");
+  const bin = join(root, "bin");
+  const configDir = join(home, ".clawde/config");
+  const configPath = join(configDir, "clawde.toml");
+
+  try {
+    Bun.spawnSync(["mkdir", "-p", bin, configDir], { stderr: "inherit" });
+    writeExecutable(join(bin, "bun"), "#!/usr/bin/env bash\nexit 1\n");
+    writeExecutable(join(bin, "claude"), "#!/usr/bin/env bash\necho claude\n");
+    writeFileSync(configPath, initialConfig);
+
+    const result = Bun.spawnSync(["bash", SCRIPT_PATH], {
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    return {
+      exitCode: result.exitCode,
+      configPath,
+      configText: readFileSync(configPath, "utf-8"),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function countWorkerSections(toml: string): number {
+  return (toml.match(/^\[worker\]\s*$/gm) ?? []).length;
+}
+
+describe("scripts/setup-linux.sh", () => {
+  test("insere chave ativa quando só há comentário e não duplica [worker]", () => {
+    const initial = `[worker]
+max_parallel = 1
+# claude_executable_path = "~/.clawde/bin/claude"
+`;
+
+    const result = runSetupLinux(initial);
+    expect(result.exitCode).toBe(0);
+    expect(countWorkerSections(result.configText)).toBe(1);
+    expect(result.configText).toContain('claude_executable_path = "');
+    expect(result.configText).toContain("# claude_executable_path = ");
+  });
+
+  test("quando [worker] existe sem chave, não cria segundo bloco [worker]", () => {
+    const initial = `[worker]
+max_parallel = 1
+
+[quota]
+plan = "max5x"
+`;
+
+    const result = runSetupLinux(initial);
+    expect(result.exitCode).toBe(0);
+    expect(countWorkerSections(result.configText)).toBe(1);
+    expect(result.configText).toContain('claude_executable_path = "');
+  });
+
+  test("idempotente: segunda execução não duplica chave", () => {
+    const initial = `[worker]
+max_parallel = 1
+`;
+
+    const first = runSetupLinux(initial);
+    expect(first.exitCode).toBe(0);
+
+    const second = runSetupLinux(first.configText);
+    expect(second.exitCode).toBe(0);
+    expect((second.configText.match(/^\s*claude_executable_path\s*=/gm) ?? []).length).toBe(1);
+    expect(countWorkerSections(second.configText)).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #41
Closes #43
Closes #47

## Workstream
A — Runtime packaging and SDK executable resolution.

## What changed
- adds optional `worker.claude_executable_path` to config schema
- passes `pathToClaudeCodeExecutable` into `RealAgentClient`
- adds `scripts/setup-linux.sh` to wire an explicit Linux binary into `~/.clawde/bin/claude`
- documents Linux deploy flow in `docs/DEPLOY-LINUX.md`
- covers config parsing, script exec bit, and worker bootstrap dry-run with configured executable path

## Acceptance criteria
- [x] `WorkerSchema` accepts `claude_executable_path`
- [x] worker passes `pathToClaudeCodeExecutable` when configured
- [x] backward compatible when config field is absent
- [x] `scripts/setup-linux.sh` is executable and idempotent in structure
- [x] `config/clawde.toml.example` documents the field
- [x] `docs/DEPLOY-LINUX.md` documents the deploy flow
- [x] tests added for config, script exec bit, and worker bootstrap path wiring

## Verification
- [x] `bun run ci`
- [x] `bun run build:worker`
- [x] `bash -n scripts/setup-linux.sh`

## Notes for reviewer
The script targets the SDK optional native packages currently present in `node_modules` (`@anthropic-ai/claude-agent-sdk-linux-x64` and `@anthropic-ai/claude-agent-sdk-linux-x64-musl`) and falls back to `which claude` for WSL/system PATH mismatches.

🤖 Implemented by Codex