### PR TITLE
fix(deploy): deferred-check timer — quota wake-up (#44)

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -546,6 +546,21 @@ clawde smoke-test || exit 1
 Falha → email/Telegram para operador, worker entra em quarentena (recusa novas tasks até
 operator clear).
 
+### 5.5.1 Deferred task wake-up timer
+
+Tasks deferidas por quota dependem de um timer independente do receiver para
+voltar a ser observadas quando `not_before` expira.
+
+- `clawde-deferred-check.timer` roda com `OnUnitActiveSec=30min`.
+- `OnBootSec=5min` garante retomada após reboot.
+- `Persistent=true` recupera janelas perdidas enquanto a máquina estava offline.
+
+Ativação:
+
+```bash
+systemctl --user enable --now clawde-deferred-check.timer
+```
+
 ### 5.6 Quota simulation
 
 Testa modelo de quota (§6.6 do ARCHITECTURE) sem consumir quota real:

--- a/deploy/systemd/clawde-deferred-check.service
+++ b/deploy/systemd/clawde-deferred-check.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Clawde deferred task check (processa tasks com not_before expirado)
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/.clawde
+EnvironmentFile=-%h/.clawde/config/clawde.env
+ExecStart=%h/.bun/bin/bun run %h/.clawde/dist/worker-main.js
+
+# Hardening idêntico ao worker (BEST_PRACTICES §10.4)
+PrivateTmp=yes
+ProtectHome=read-only
+ProtectSystem=strict
+NoNewPrivileges=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+ReadWritePaths=%h/.clawde /tmp
+
+[Install]
+WantedBy=default.target

--- a/deploy/systemd/clawde-deferred-check.timer
+++ b/deploy/systemd/clawde-deferred-check.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Clawde deferred task check (a cada 30 minutos)
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=30min
+Unit=clawde-deferred-check.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/tests/unit/sandbox/systemd.test.ts
+++ b/tests/unit/sandbox/systemd.test.ts
@@ -127,6 +127,22 @@ describe("deploy/systemd unit files reais", () => {
     expect(content).toContain("ExecStart=%h/.clawde/dist/clawde diagnose db --output json");
   });
 
+  test("clawde-deferred-check.timer roda a cada 30min e no boot", () => {
+    const content = readUnit("clawde-deferred-check.timer");
+    expect(content).toContain("OnUnitActiveSec=30min");
+    expect(content).toContain("OnBootSec=5min");
+    expect(content).toContain("Persistent=true");
+    expect(content).toContain("Unit=clawde-deferred-check.service");
+  });
+
+  test("clawde-deferred-check.service invoca worker com hardening", () => {
+    const content = readUnit("clawde-deferred-check.service");
+    expect(content).toContain("ExecStart=%h/.bun/bin/bun run %h/.clawde/dist/worker-main.js");
+    expect(content).toContain("Type=oneshot");
+    expect(content).toContain("NoNewPrivileges=yes");
+    expect(content).toContain("ReadWritePaths=%h/.clawde /tmp");
+  });
+
   test("clawde-events-retention.timer roda mensal dia 1 às 04:00", () => {
     const content = readUnit("clawde-events-retention.timer");
     expect(content).toContain("OnCalendar=*-*-01 04:00:00");


### PR DESCRIPTION
Closes #44

## Workstream
B — Deferred task wake-up after quota reset.

## What changed
- adds `deploy/systemd/clawde-deferred-check.service`
- adds `deploy/systemd/clawde-deferred-check.timer`
- documents the deferred wake-up timer in `BEST_PRACTICES.md`
- extends systemd unit tests to cover schedule and hardening

## Acceptance criteria
- [x] timer has `OnUnitActiveSec=30min`, `OnBootSec=5min`, `Persistent=true`
- [x] service invokes the existing worker entrypoint
- [x] service mirrors worker hardening
- [x] tests cover timer schedule and service hardening
- [x] no changes to `src/worker/*`, `src/db/*`, or quota logic

## Verification
- [x] `bun test tests/unit/sandbox/systemd.test.ts`
- [x] `bun run ci`

## Notes for reviewer
The repo currently runs the worker through `bun run %h/.clawde/dist/worker-main.js`, so the deferred-check service follows the live unit convention instead of the older plan text that referenced a standalone `clawde-worker` binary.

🤖 Implemented by Codex