### PR TITLE
fix(worker): wire review pipeline into bootstrap (issue #59)

### DIFF
--- a/src/hooks/handlers.ts
+++ b/src/hooks/handlers.ts
@@ -6,281 +6,318 @@
  * virão em Fase 6.
  */
 
-import { join, isAbsolute } from "node:path";
+import { isAbsolute, join } from "node:path";
 import type { ObservationKind } from "@clawde/domain/memory";
 import type {
-  HookHandler,
-  HookInput,
-  HookOutput,
-  PostToolUsePayload,
-  PreToolUsePayload,
-  SessionStartPayload,
-  StopPayload,
-  UserPromptSubmitPayload,
+	HookHandler,
+	HookInput,
+	HookOutput,
+	PostToolUsePayload,
+	PreToolUsePayload,
+	SessionStartPayload,
+	StopPayload,
+	UserPromptSubmitPayload,
 } from "./types.ts";
 
-export type EventCallback = (kind: string, payload: Record<string, unknown>) => void;
+export type EventCallback = (
+	kind: string,
+	payload: Record<string, unknown>,
+) => void;
 
 /**
  * F5.T50: callback opcional pra persistir observation em memory_observations.
  * Quando undefined, hook só emite event (comportamento Fase 2).
  */
 export type MemoryCallback = (input: {
-  sessionId: string;
-  kind: ObservationKind;
-  content: string;
-  importance: number;
+	sessionId: string;
+	kind: ObservationKind;
+	content: string;
+	importance: number;
 }) => void;
 
 export interface PreToolUseAgentPolicy {
-  readonly allowedTools: ReadonlyArray<string>;
-  readonly sandbox: {
-    readonly level: 1 | 2 | 3;
-    readonly allowed_writes: ReadonlyArray<string>;
-    /**
-     * Path allowlist for `Read`. Semantics:
-     *   - `undefined`     → no enforcement (legacy behavior, all reads allowed).
-     *   - `[]` (defined)  → fail-closed, NO reads allowed.
-     *   - non-empty list  → strict allowlist (read iff target matches a prefix).
-     *
-     * The "defined empty" form is the one to use for adversarial-input agents
-     * (telegram-bot, github-pr-handler) — closes the exfiltration vector where
-     * an attacker socially engineers the agent to read secrets and the response
-     * is auto-forwarded back.
-     */
-    readonly allowed_reads?: ReadonlyArray<string>;
-    /** Working directory used to resolve relative paths in write/read checks. */
-    readonly cwd?: string;
-  };
+	readonly allowedTools: ReadonlyArray<string>;
+	readonly sandbox: {
+		readonly level: 1 | 2 | 3;
+		readonly allowed_writes: ReadonlyArray<string>;
+		/**
+		 * Path allowlist for `Read`. Semantics:
+		 *   - `undefined`     → no enforcement (legacy behavior, all reads allowed).
+		 *   - `[]` (defined)  → fail-closed, NO reads allowed.
+		 *   - non-empty list  → strict allowlist (read iff target matches a prefix).
+		 *
+		 * The "defined empty" form is the one to use for adversarial-input agents
+		 * (telegram-bot, github-pr-handler) — closes the exfiltration vector where
+		 * an attacker socially engineers the agent to read secrets and the response
+		 * is auto-forwarded back.
+		 */
+		readonly allowed_reads?: ReadonlyArray<string>;
+		/** Working directory used to resolve relative paths in write/read checks. */
+		readonly cwd?: string;
+	};
 }
 
-function summarizeBashCommand(toolInput: Readonly<Record<string, unknown>>): string {
-  const raw = toolInput.command;
-  if (typeof raw !== "string") return "";
-  return raw.slice(0, 80);
+function summarizeBashCommand(
+	toolInput: Readonly<Record<string, unknown>>,
+): string {
+	const raw = toolInput.command;
+	if (typeof raw !== "string") return "";
+	return raw.slice(0, 80);
 }
 
 function extractPath(toolInput: Readonly<Record<string, unknown>>): string {
-  const candidates = [toolInput.path, toolInput.file_path];
-  for (const candidate of candidates) {
-    if (typeof candidate === "string") return candidate;
-  }
-  return "";
+	const candidates = [toolInput.path, toolInput.file_path];
+	for (const candidate of candidates) {
+		if (typeof candidate === "string") return candidate;
+	}
+	return "";
 }
 
-function estimateWriteBytes(toolInput: Readonly<Record<string, unknown>>): number {
-  const candidates = [
-    toolInput.content,
-    toolInput.text,
-    toolInput.newText,
-    toolInput.new_str,
-    toolInput.old_str,
-    toolInput.patch,
-  ];
-  for (const candidate of candidates) {
-    if (typeof candidate === "string") {
-      return Buffer.byteLength(candidate, "utf-8");
-    }
-  }
-  return 0;
+function estimateWriteBytes(
+	toolInput: Readonly<Record<string, unknown>>,
+): number {
+	const candidates = [
+		toolInput.content,
+		toolInput.text,
+		toolInput.newText,
+		toolInput.new_str,
+		toolInput.old_str,
+		toolInput.patch,
+	];
+	for (const candidate of candidates) {
+		if (typeof candidate === "string") {
+			return Buffer.byteLength(candidate, "utf-8");
+		}
+	}
+	return 0;
 }
 
 function summarizeToolUse(
-  toolName: string,
-  toolInput: Readonly<Record<string, unknown>>,
+	toolName: string,
+	toolInput: Readonly<Record<string, unknown>>,
 ): Record<string, unknown> {
-  if (toolName === "Bash") {
-    return {
-      tool_name: "Bash",
-      command_summary: summarizeBashCommand(toolInput),
-    };
-  }
-  if (toolName === "Read") {
-    return {
-      tool_name: "Read",
-      path: extractPath(toolInput),
-    };
-  }
-  if (toolName === "Edit" || toolName === "Write") {
-    return {
-      tool_name: toolName,
-      path: extractPath(toolInput),
-      bytes_count: estimateWriteBytes(toolInput),
-    };
-  }
-  return { tool_name: toolName };
+	if (toolName === "Bash") {
+		return {
+			tool_name: "Bash",
+			command_summary: summarizeBashCommand(toolInput),
+		};
+	}
+	if (toolName === "Read") {
+		return {
+			tool_name: "Read",
+			path: extractPath(toolInput),
+		};
+	}
+	if (toolName === "Edit" || toolName === "Write") {
+		return {
+			tool_name: toolName,
+			path: extractPath(toolInput),
+			bytes_count: estimateWriteBytes(toolInput),
+		};
+	}
+	return { tool_name: toolName };
 }
 
 function normalizePath(input: string): string {
-  return input.replace(/\\/g, "/").trim();
+	return input.replace(/\\/g, "/").trim();
 }
 
 function isPathTraversal(path: string): boolean {
-  const p = normalizePath(path);
-  return p.includes("../") || p.startsWith("..");
+	const p = normalizePath(path);
+	return p.includes("../") || p.startsWith("..");
 }
 
 function isAllowedWritePath(
-  path: string,
-  allowedWrites: ReadonlyArray<string>,
-  cwd?: string,
+	path: string,
+	allowedWrites: ReadonlyArray<string>,
+	cwd?: string,
 ): boolean {
-  let target = normalizePath(path);
-  if (isPathTraversal(target)) return false;
-  // Resolve relative paths against cwd so "/workspace" → "/tmp/clawde-N" mapping works.
-  if (!isAbsolute(target) && cwd !== undefined) {
-    target = normalizePath(join(cwd, target));
-  }
-  for (const allowed of allowedWrites) {
-    const base = normalizePath(allowed);
-    if (base.length === 0) continue;
-    if (target === base || target.startsWith(`${base}/`)) return true;
-  }
-  return false;
+	let target = normalizePath(path);
+	if (isPathTraversal(target)) return false;
+	// Resolve relative paths against cwd so "/workspace" → "/tmp/clawde-N" mapping works.
+	if (!isAbsolute(target) && cwd !== undefined) {
+		target = normalizePath(join(cwd, target));
+	}
+	for (const allowed of allowedWrites) {
+		const base = normalizePath(allowed);
+		if (base.length === 0) continue;
+		if (target === base || target.startsWith(`${base}/`)) return true;
+	}
+	return false;
 }
 
-function isAllowedReadPath(path: string, allowedReads: ReadonlyArray<string>): boolean {
-  const target = normalizePath(path);
-  if (isPathTraversal(target)) return false;
-  for (const allowed of allowedReads) {
-    const base = normalizePath(allowed);
-    if (base.length === 0) continue;
-    if (target === base || target.startsWith(`${base}/`)) return true;
-  }
-  return false;
+function isAllowedReadPath(
+	path: string,
+	allowedReads: ReadonlyArray<string>,
+): boolean {
+	const target = normalizePath(path);
+	if (isPathTraversal(target)) return false;
+	for (const allowed of allowedReads) {
+		const base = normalizePath(allowed);
+		if (base.length === 0) continue;
+		if (target === base || target.startsWith(`${base}/`)) return true;
+	}
+	return false;
 }
 
 export function makeSessionStartHandler(
-  emit: EventCallback,
-): HookHandler<HookInput & { hook: "SessionStart"; payload: SessionStartPayload }> {
-  return (input) => {
-    emit("session_start_hook", { agent: input.payload.agent });
-    return { ok: true };
-  };
+	emit: EventCallback,
+): HookHandler<
+	HookInput & { hook: "SessionStart"; payload: SessionStartPayload }
+> {
+	return (input) => {
+		emit("session_start_hook", { agent: input.payload.agent });
+		return { ok: true };
+	};
 }
 
 export function makeUserPromptSubmitHandler(
-  emit: EventCallback,
-): HookHandler<HookInput & { hook: "UserPromptSubmit"; payload: UserPromptSubmitPayload }> {
-  return (input) => {
-    // No-op por padrão; prompt-guard real virá em Fase 6 (sanitização).
-    emit("user_prompt_submit_hook", {
-      source: input.payload.source ?? "unknown",
-      prompt_len: input.payload.prompt.length,
-    });
-    return { ok: true };
-  };
+	emit: EventCallback,
+): HookHandler<
+	HookInput & { hook: "UserPromptSubmit"; payload: UserPromptSubmitPayload }
+> {
+	return (input) => {
+		// No-op por padrão; prompt-guard real virá em Fase 6 (sanitização).
+		emit("user_prompt_submit_hook", {
+			source: input.payload.source ?? "unknown",
+			prompt_len: input.payload.prompt.length,
+		});
+		return { ok: true };
+	};
 }
 
 export function makePreToolUseHandler(
-  emit: EventCallback,
-  agent?: PreToolUseAgentPolicy,
+	emit: EventCallback,
+	agent?: PreToolUseAgentPolicy,
 ): HookHandler<HookInput & { hook: "PreToolUse"; payload: PreToolUsePayload }> {
-  return (input) => {
-    const toolName = input.payload.toolName;
-    const allowedTools = agent?.allowedTools ?? [];
+	return (input) => {
+		const toolName = input.payload.toolName;
+		const allowedTools = agent?.allowedTools ?? [];
 
-    if (allowedTools.length > 0 && !allowedTools.includes(toolName)) {
-      emit("tool_blocked", {
-        tool: toolName,
-        reason: "tool_not_allowlisted",
-      });
-      return { ok: false, block: true, message: `tool '${toolName}' not allowed` };
-    }
+		if (allowedTools.length > 0 && !allowedTools.includes(toolName)) {
+			emit("tool_blocked", {
+				tool: toolName,
+				reason: "tool_not_allowlisted",
+			});
+			return {
+				ok: false,
+				block: true,
+				message: `tool '${toolName}' not allowed`,
+			};
+		}
 
-    if (toolName === "Bash" && (agent?.sandbox.level ?? 1) >= 2) {
-      emit("tool_blocked", {
-        tool: toolName,
-        reason: "bash_requires_subprocess_wrapper",
-        sandbox_level: agent?.sandbox.level ?? 1,
-      });
-      return {
-        ok: false,
-        block: true,
-        message: "Bash blocked on sandbox level>=2 until subprocess wrapper is available",
-      };
-    }
+		if (toolName === "Bash" && (agent?.sandbox.level ?? 1) >= 2) {
+			emit("tool_blocked", {
+				tool: toolName,
+				reason: "bash_requires_subprocess_wrapper",
+				sandbox_level: agent?.sandbox.level ?? 1,
+			});
+			return {
+				ok: false,
+				block: true,
+				message:
+					"Bash blocked on sandbox level>=2 until subprocess wrapper is available",
+			};
+		}
 
-    if (toolName === "Edit" || toolName === "Write") {
-      const path = extractPath(input.payload.toolInput);
-      const allowedWrites = agent?.sandbox.allowed_writes ?? [];
-      if (allowedWrites.length > 0 && !isAllowedWritePath(path, allowedWrites, agent?.sandbox.cwd)) {
-        emit("tool_blocked", {
-          tool: toolName,
-          reason: "write_path_not_allowed",
-          path,
-        });
-        return { ok: false, block: true, message: `write path '${path}' is not allowed` };
-      }
-    }
+		if (toolName === "Edit" || toolName === "Write") {
+			const path = extractPath(input.payload.toolInput);
+			const allowedWrites = agent?.sandbox.allowed_writes ?? [];
+			if (
+				allowedWrites.length > 0 &&
+				!isAllowedWritePath(path, allowedWrites, agent?.sandbox.cwd)
+			) {
+				emit("tool_blocked", {
+					tool: toolName,
+					reason: "write_path_not_allowed",
+					path,
+				});
+				return {
+					ok: false,
+					block: true,
+					message: `write path '${path}' is not allowed`,
+				};
+			}
+		}
 
-    // Read path policy: enforced apenas quando `allowed_reads` está definido
-    // (mesmo que vazio). `undefined` mantém comportamento legacy permissivo.
-    // Empty array = fail-closed, evita exfiltração via Read pra agentes que
-    // processam input adversarial com auto-resposta (telegram-bot, etc).
-    if (toolName === "Read" && agent?.sandbox.allowed_reads !== undefined) {
-      const path = extractPath(input.payload.toolInput);
-      if (!isAllowedReadPath(path, agent.sandbox.allowed_reads)) {
-        emit("tool_blocked", {
-          tool: toolName,
-          reason: "read_path_not_allowed",
-          path,
-        });
-        return { ok: false, block: true, message: `read path '${path}' is not allowed` };
-      }
-    }
+		// Read path policy: enforced apenas quando `allowed_reads` está definido
+		// (mesmo que vazio). `undefined` mantém comportamento legacy permissivo.
+		// Empty array = fail-closed, evita exfiltração via Read pra agentes que
+		// processam input adversarial com auto-resposta (telegram-bot, etc).
+		if (toolName === "Read" && agent?.sandbox.allowed_reads !== undefined) {
+			const path = extractPath(input.payload.toolInput);
+			if (!isAllowedReadPath(path, agent.sandbox.allowed_reads)) {
+				emit("tool_blocked", {
+					tool: toolName,
+					reason: "read_path_not_allowed",
+					path,
+				});
+				return {
+					ok: false,
+					block: true,
+					message: `read path '${path}' is not allowed`,
+				};
+			}
+		}
 
-    emit("tool_use", summarizeToolUse(input.payload.toolName, input.payload.toolInput));
-    return { ok: true };
-  };
+		emit(
+			"tool_use",
+			summarizeToolUse(input.payload.toolName, input.payload.toolInput),
+		);
+		return { ok: true };
+	};
 }
 
 export function makePostToolUseHandler(
-  emit: EventCallback,
-  memoryCallback?: MemoryCallback,
-): HookHandler<HookInput & { hook: "PostToolUse"; payload: PostToolUsePayload }> {
-  return (input) => {
-    emit("tool_result", {
-      tool: input.payload.toolName,
-      duration_ms: input.payload.durationMs,
-      exit_code: input.payload.exitCode ?? null,
-    });
-    if (memoryCallback !== undefined) {
-      // Resumo concise do tool use pra observation searchable.
-      const summary = `tool=${input.payload.toolName} duration=${input.payload.durationMs}ms${
-        input.payload.exitCode !== undefined ? ` exit=${input.payload.exitCode}` : ""
-      }`;
-      memoryCallback({
-        sessionId: input.sessionId,
-        kind: "observation",
-        content: summary,
-        importance: 0.4, // tool calls são baixa importância por default
-      });
-    }
-    return { ok: true };
-  };
+	emit: EventCallback,
+	memoryCallback?: MemoryCallback,
+): HookHandler<
+	HookInput & { hook: "PostToolUse"; payload: PostToolUsePayload }
+> {
+	return (input) => {
+		emit("tool_result", {
+			tool: input.payload.toolName,
+			duration_ms: input.payload.durationMs,
+			exit_code: input.payload.exitCode ?? null,
+		});
+		if (memoryCallback !== undefined) {
+			// Resumo concise do tool use pra observation searchable.
+			const summary = `tool=${input.payload.toolName} duration=${input.payload.durationMs}ms${
+				input.payload.exitCode !== undefined
+					? ` exit=${input.payload.exitCode}`
+					: ""
+			}`;
+			memoryCallback({
+				sessionId: input.sessionId,
+				kind: "observation",
+				content: summary,
+				importance: 0.4, // tool calls são baixa importância por default
+			});
+		}
+		return { ok: true };
+	};
 }
 
 export function makeStopHandler(
-  emit: EventCallback,
-  memoryCallback?: MemoryCallback,
+	emit: EventCallback,
+	memoryCallback?: MemoryCallback,
 ): HookHandler<HookInput & { hook: "Stop"; payload: StopPayload }> {
-  return (input) => {
-    emit("session_stop_hook", {
-      reason: input.payload.reason,
-      msgs_consumed: input.payload.msgsConsumed,
-      total_turns: input.payload.totalTurns,
-    });
-    if (memoryCallback !== undefined && input.payload.finalText !== undefined) {
-      // Stop com finalText é summary de alto valor — importance maior.
-      const truncated = input.payload.finalText.slice(0, 2000);
-      memoryCallback({
-        sessionId: input.sessionId,
-        kind: "summary",
-        content: truncated,
-        importance: 0.6,
-      });
-    }
-    return { ok: true } as HookOutput;
-  };
+	return (input) => {
+		emit("session_stop_hook", {
+			reason: input.payload.reason,
+			msgs_consumed: input.payload.msgsConsumed,
+			total_turns: input.payload.totalTurns,
+		});
+		if (memoryCallback !== undefined && input.payload.finalText !== undefined) {
+			// Stop com finalText é summary de alto valor — importance maior.
+			const truncated = input.payload.finalText.slice(0, 2000);
+			memoryCallback({
+				sessionId: input.sessionId,
+				kind: "summary",
+				content: truncated,
+				importance: 0.6,
+			});
+		}
+		return { ok: true } as HookOutput;
+	};
 }

--- a/src/hooks/handlers.ts
+++ b/src/hooks/handlers.ts
@@ -6,6 +6,7 @@
  * virão em Fase 6.
  */
 
+import { join, isAbsolute } from "node:path";
 import type { ObservationKind } from "@clawde/domain/memory";
 import type {
   HookHandler,
@@ -48,6 +49,8 @@ export interface PreToolUseAgentPolicy {
      * is auto-forwarded back.
      */
     readonly allowed_reads?: ReadonlyArray<string>;
+    /** Working directory used to resolve relative paths in write/read checks. */
+    readonly cwd?: string;
   };
 }
 
@@ -117,9 +120,17 @@ function isPathTraversal(path: string): boolean {
   return p.includes("../") || p.startsWith("..");
 }
 
-function isAllowedWritePath(path: string, allowedWrites: ReadonlyArray<string>): boolean {
-  const target = normalizePath(path);
+function isAllowedWritePath(
+  path: string,
+  allowedWrites: ReadonlyArray<string>,
+  cwd?: string,
+): boolean {
+  let target = normalizePath(path);
   if (isPathTraversal(target)) return false;
+  // Resolve relative paths against cwd so "/workspace" → "/tmp/clawde-N" mapping works.
+  if (!isAbsolute(target) && cwd !== undefined) {
+    target = normalizePath(join(cwd, target));
+  }
   for (const allowed of allowedWrites) {
     const base = normalizePath(allowed);
     if (base.length === 0) continue;
@@ -193,7 +204,7 @@ export function makePreToolUseHandler(
     if (toolName === "Edit" || toolName === "Write") {
       const path = extractPath(input.payload.toolInput);
       const allowedWrites = agent?.sandbox.allowed_writes ?? [];
-      if (allowedWrites.length > 0 && !isAllowedWritePath(path, allowedWrites)) {
+      if (allowedWrites.length > 0 && !isAllowedWritePath(path, allowedWrites, agent?.sandbox.cwd)) {
         emit("tool_blocked", {
           tool: toolName,
           reason: "write_path_not_allowed",

--- a/src/review/prompts.ts
+++ b/src/review/prompts.ts
@@ -74,6 +74,10 @@ export function buildReviewerPrompt(taskSpec: string, implementerOutput: string)
     "```",
     implementerOutput,
     "```",
+    "",
+    "Review the output above against the spec. End your response with exactly one of:",
+    "VERDICT: APPROVED",
+    "VERDICT: REJECTED",
   ].join("\n");
 }
 

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -32,6 +32,11 @@ export {
   validateEgressList,
 } from "./netns.ts";
 export {
+  type SandboxedWrapper,
+  makeSandboxedClaudeWrapper,
+  resolveClaudeNativeBinary,
+} from "./wrapper.ts";
+export {
   type PathUnitInput,
   type ServiceUnitInput,
   type TimerUnitInput,

--- a/src/sandbox/wrapper.ts
+++ b/src/sandbox/wrapper.ts
@@ -1,0 +1,87 @@
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildBwrapArgs } from "./bwrap.ts";
+
+const CLAUDE_AGENT_SDK_LINUX_X64 =
+  "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude";
+
+/**
+ * Resolve the native claude binary bundled with the SDK, falling back to the
+ * system claude if the SDK binary is not present.
+ */
+export function resolveClaudeNativeBinary(projectRoot = process.cwd()): string {
+  const candidate = join(projectRoot, CLAUDE_AGENT_SDK_LINUX_X64);
+  if (existsSync(candidate)) return candidate;
+  return "/usr/local/bin/claude";
+}
+
+export interface SandboxedWrapper {
+  readonly wrapperPath: string;
+  cleanup(): void;
+}
+
+/**
+ * Creates a temp directory containing a `claude` wrapper script that runs the
+ * real claude binary inside bwrap with filesystem isolation.
+ *
+ * Network is intentionally kept as "host" — the claude binary needs egress to
+ * api.anthropic.com. Full network isolation (loopback-only) is deferred to
+ * Fase 6C, which requires a local API proxy (nftables backend, issue #49).
+ *
+ * Returns the wrapper path and a cleanup function.
+ */
+export function makeSandboxedClaudeWrapper(
+  agentName: string,
+  agentReadOnlyMounts: ReadonlyArray<string>,
+  env: Record<string, string | undefined>,
+  projectRoot?: string,
+): SandboxedWrapper {
+  const claudeBinary = resolveClaudeNativeBinary(projectRoot);
+  const home = homedir();
+  const claudeConfigDir = env.CLAUDE_CONFIG_DIR ?? join(home, ".claude");
+
+  const bwrapArgs = buildBwrapArgs(
+    {
+      bwrapPath: "/usr/bin/bwrap",
+      readOnlyMounts: [
+        ...agentReadOnlyMounts,
+        ...(existsSync(claudeConfigDir) ? [claudeConfigDir] : []),
+        ...(existsSync(join(home, ".claude.json")) ? [join(home, ".claude.json")] : []),
+      ],
+      readWritePaths: [{ host: tmpdir(), sandbox: tmpdir() }],
+      // host network: API egress required (see function doc above)
+      network: "host",
+      workdir: tmpdir(),
+      env: {
+        HOME: home,
+        TMPDIR: tmpdir(),
+        PATH: "/usr/bin:/usr/local/bin:/bin",
+        CLAUDE_CODE_ENTRYPOINT: "sdk-ts",
+        ...(env.CLAUDE_CODE_OAUTH_TOKEN
+          ? { CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN }
+          : {}),
+        ...(env.CLAUDE_CONFIG_DIR ? { CLAUDE_CONFIG_DIR: env.CLAUDE_CONFIG_DIR } : {}),
+        ...(env.ANTHROPIC_API_KEY ? { ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY } : {}),
+      },
+    },
+    claudeBinary,
+    [],
+  );
+
+  // All args except the last item (the claude binary path, which we append with "$@")
+  const configArgs = bwrapArgs.slice(0, -1);
+  const quotedArgs = configArgs.map(shellQuote).join(" ");
+  const script = `#!/bin/sh\nexec /usr/bin/bwrap ${quotedArgs} ${shellQuote(claudeBinary)} "$@"\n`;
+
+  const tmpDir = mkdtempSync(join(tmpdir(), `clawde-wrap-${agentName}-`));
+  const wrapperPath = join(tmpDir, "claude");
+  writeFileSync(wrapperPath, script, { encoding: "utf-8" });
+  chmodSync(wrapperPath, 0o755);
+
+  return { wrapperPath, cleanup: () => rmSync(tmpDir, { recursive: true, force: true }) };
+}
+
+function shellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}

--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -91,6 +91,8 @@ export class RealAgentClient implements AgentClient {
       if (options.workingDirectory !== undefined) queryOptions.cwd = options.workingDirectory;
       if (options.resumeSessionId !== undefined)
         queryOptions.resumeSessionId = options.resumeSessionId;
+      if (options.claudeExecutablePath !== undefined)
+        queryOptions.pathToClaudeCodeExecutable = options.claudeExecutablePath;
 
       // Lazy: parser.ts re-importado para evitar circularidade.
       const { parseRawMessage } = await import("./parser.ts");

--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -3,31 +3,38 @@
  * Padrões inspirados em claude-mem/src/sdk/parser.ts.
  */
 
-import type { ContentBlock, ParsedMessage, TextBlock, ToolUseBlock } from "./types.ts";
+import type {
+	ContentBlock,
+	ParsedMessage,
+	TextBlock,
+	ToolUseBlock,
+} from "./types.ts";
 
 export function isTextBlock(b: ContentBlock): b is TextBlock {
-  return b.type === "text";
+	return b.type === "text";
 }
 
 export function isToolUseBlock(b: ContentBlock): b is ToolUseBlock {
-  return b.type === "tool_use";
+	return b.type === "tool_use";
 }
 
 /**
  * Extrai texto concatenado de uma mensagem (skip tool_use/tool_result).
  */
 export function extractText(message: ParsedMessage): string {
-  return message.blocks
-    .filter(isTextBlock)
-    .map((b) => b.text)
-    .join("\n");
+	return message.blocks
+		.filter(isTextBlock)
+		.map((b) => b.text)
+		.join("\n");
 }
 
 /**
  * Lista tool_uses de uma mensagem.
  */
-export function extractToolUses(message: ParsedMessage): ReadonlyArray<ToolUseBlock> {
-  return message.blocks.filter(isToolUseBlock);
+export function extractToolUses(
+	message: ParsedMessage,
+): ReadonlyArray<ToolUseBlock> {
+	return message.blocks.filter(isToolUseBlock);
 }
 
 /**
@@ -37,46 +44,65 @@ export function extractToolUses(message: ParsedMessage): ReadonlyArray<ToolUseBl
  * Espera entrada com `{type, role?, content?: array | string}`.
  */
 export function parseRawMessage(raw: unknown): ParsedMessage | null {
-  if (raw === null || typeof raw !== "object") return null;
-  const obj = raw as Record<string, unknown>;
-  const role = (obj.role ?? obj.message_role ?? "assistant") as string;
-  if (role !== "user" && role !== "assistant" && role !== "system" && role !== "tool") {
-    return null;
-  }
+	if (raw === null || typeof raw !== "object") return null;
+	const obj = raw as Record<string, unknown>;
 
-  const content = obj.content ?? obj.text ?? obj.message;
-  const blocks: ContentBlock[] = [];
+	// SDKAssistantMessage: {type: 'assistant', message: BetaMessage, uuid, session_id}
+	// The actual content is nested inside message.content — unwrap and recurse.
+	if (
+		obj.type === "assistant" &&
+		obj.message !== null &&
+		typeof obj.message === "object"
+	) {
+		return parseRawMessage(obj.message);
+	}
 
-  if (typeof content === "string") {
-    blocks.push({ type: "text", text: content });
-  } else if (Array.isArray(content)) {
-    for (const item of content) {
-      if (typeof item === "string") {
-        blocks.push({ type: "text", text: item });
-        continue;
-      }
-      if (item === null || typeof item !== "object") continue;
-      const b = item as Record<string, unknown>;
-      const btype = b.type;
-      if (btype === "text" && typeof b.text === "string") {
-        blocks.push({ type: "text", text: b.text });
-      } else if (btype === "tool_use") {
-        blocks.push({
-          type: "tool_use",
-          name: String(b.name ?? "unknown"),
-          input: (b.input ?? {}) as Readonly<Record<string, unknown>>,
-          id: String(b.id ?? ""),
-        });
-      } else if (btype === "tool_result") {
-        blocks.push({
-          type: "tool_result",
-          toolUseId: String(b.tool_use_id ?? b.toolUseId ?? ""),
-          content: typeof b.content === "string" ? b.content : JSON.stringify(b.content),
-          isError: Boolean(b.is_error ?? b.isError ?? false),
-        });
-      }
-    }
-  }
+	const role = (obj.role ?? obj.message_role ?? "assistant") as string;
+	if (
+		role !== "user" &&
+		role !== "assistant" &&
+		role !== "system" &&
+		role !== "tool"
+	) {
+		return null;
+	}
 
-  return { role: role as ParsedMessage["role"], blocks, raw };
+	const content = obj.content ?? obj.text ?? obj.message;
+	const blocks: ContentBlock[] = [];
+
+	if (typeof content === "string") {
+		blocks.push({ type: "text", text: content });
+	} else if (Array.isArray(content)) {
+		for (const item of content) {
+			if (typeof item === "string") {
+				blocks.push({ type: "text", text: item });
+				continue;
+			}
+			if (item === null || typeof item !== "object") continue;
+			const b = item as Record<string, unknown>;
+			const btype = b.type;
+			if (btype === "text" && typeof b.text === "string") {
+				blocks.push({ type: "text", text: b.text });
+			} else if (btype === "tool_use") {
+				blocks.push({
+					type: "tool_use",
+					name: String(b.name ?? "unknown"),
+					input: (b.input ?? {}) as Readonly<Record<string, unknown>>,
+					id: String(b.id ?? ""),
+				});
+			} else if (btype === "tool_result") {
+				blocks.push({
+					type: "tool_result",
+					toolUseId: String(b.tool_use_id ?? b.toolUseId ?? ""),
+					content:
+						typeof b.content === "string"
+							? b.content
+							: JSON.stringify(b.content),
+					isError: Boolean(b.is_error ?? b.isError ?? false),
+				});
+			}
+		}
+	}
+
+	return { role: role as ParsedMessage["role"], blocks, raw };
 }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -85,6 +85,8 @@ export interface RunAgentOptions {
   readonly appendSystemPrompt?: string;
   readonly workingDirectory?: string;
   readonly bare?: boolean;
+  /** Path to a custom claude executable (e.g. a bwrap wrapper script for sandboxed agents). */
+  readonly claudeExecutablePath?: string;
 }
 
 /**

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -1,13 +1,16 @@
 import { homedir, hostname } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { AgentDefinitionError, loadAllAgentDefinitionsWithWarnings } from "@clawde/agents";
+import {
+	AgentDefinitionError,
+	loadAllAgentDefinitionsWithWarnings,
+} from "@clawde/agents";
 import { sendAlertBestEffort } from "@clawde/alerts";
 import { loadConfig } from "@clawde/config";
 import { closeDb, openDb } from "@clawde/db/client";
 import {
-  SLOW_INTEGRITY_CHECK_MS,
-  isDbIntegrityOk,
-  runDbIntegrityChecks,
+	isDbIntegrityOk,
+	runDbIntegrityChecks,
+	SLOW_INTEGRITY_CHECK_MS,
 } from "@clawde/db/integrity";
 import { applyPending, defaultMigrationsDir } from "@clawde/db/migrations";
 import { EventsRepo } from "@clawde/db/repositories/events";
@@ -15,204 +18,226 @@ import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, setMinLevel } from "@clawde/log";
-import { QuotaTracker, makeQuotaPolicy } from "@clawde/quota";
+import { makeQuotaPolicy, QuotaTracker } from "@clawde/quota";
 import { RealAgentClient } from "@clawde/sdk";
-import { LeaseManager, type RunnerDeps, makeReconciler, processNextPending } from "./index.ts";
+import {
+	LeaseManager,
+	makeReconciler,
+	processNextPending,
+	type RunnerDeps,
+} from "./index.ts";
+import type { ProcessResult } from "./runner.ts";
+import { sendTelegramReply } from "./telegram-reply.ts";
 
 const DEFAULT_MAX_TASKS = 50;
 
 function expandHome(p: string): string {
-  if (p.startsWith("~/") || p === "~") return p.replace(/^~/, homedir());
-  return p;
+	if (p.startsWith("~/") || p === "~") return p.replace(/^~/, homedir());
+	return p;
 }
 
-export function parseMaxTasks(argv: ReadonlyArray<string>, fallback = DEFAULT_MAX_TASKS): number {
-  const idx = argv.indexOf("--max-tasks");
-  if (idx < 0 || idx + 1 >= argv.length) return fallback;
-  const raw = argv[idx + 1];
-  if (raw === undefined) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+export function parseMaxTasks(
+	argv: ReadonlyArray<string>,
+	fallback = DEFAULT_MAX_TASKS,
+): number {
+	const idx = argv.indexOf("--max-tasks");
+	if (idx < 0 || idx + 1 >= argv.length) return fallback;
+	const raw = argv[idx + 1];
+	if (raw === undefined) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 export function parseDryRun(argv: ReadonlyArray<string>): boolean {
-  return argv.includes("--dry-run");
+	return argv.includes("--dry-run");
 }
 
 export type LoopExitReason = "empty" | "deferred" | "max_tasks";
 
 export interface LoopResult {
-  readonly processed: number;
-  readonly exitReason: LoopExitReason;
+	readonly processed: number;
+	readonly exitReason: LoopExitReason;
 }
 
 function assertStartupDbIntegrity(
-  db: ReturnType<typeof openDb>,
-  logger: ReturnType<typeof createLogger>,
+	db: ReturnType<typeof openDb>,
+	logger: ReturnType<typeof createLogger>,
 ): void {
-  const report = runDbIntegrityChecks(db);
-  if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
-    logger.warn("startup integrity_check slow", {
-      elapsed_ms: report.elapsedMs,
-      threshold_ms: SLOW_INTEGRITY_CHECK_MS,
-    });
-  }
-  if (isDbIntegrityOk(report)) {
-    return;
-  }
+	const report = runDbIntegrityChecks(db);
+	if (report.elapsedMs > SLOW_INTEGRITY_CHECK_MS) {
+		logger.warn("startup integrity_check slow", {
+			elapsed_ms: report.elapsedMs,
+			threshold_ms: SLOW_INTEGRITY_CHECK_MS,
+		});
+	}
+	if (isDbIntegrityOk(report)) {
+		return;
+	}
 
-  const payload = {
-    integrity_check: report.integrityCheck,
-    quick_check: report.quickCheck,
-    foreign_key_violations: report.foreignKeyViolations.length,
-    elapsed_ms: report.elapsedMs,
-  } as const;
-  try {
-    new EventsRepo(db).insert({
-      taskRunId: null,
-      sessionId: null,
-      traceId: null,
-      spanId: null,
-      kind: "db_corrupted",
-      payload,
-    });
-  } catch (err) {
-    logger.error("failed to persist db_corrupted event", {
-      error: (err as Error).message,
-    });
-  }
+	const payload = {
+		integrity_check: report.integrityCheck,
+		quick_check: report.quickCheck,
+		foreign_key_violations: report.foreignKeyViolations.length,
+		elapsed_ms: report.elapsedMs,
+	} as const;
+	try {
+		new EventsRepo(db).insert({
+			taskRunId: null,
+			sessionId: null,
+			traceId: null,
+			spanId: null,
+			kind: "db_corrupted",
+			payload,
+		});
+	} catch (err) {
+		logger.error("failed to persist db_corrupted event", {
+			error: (err as Error).message,
+		});
+	}
 
-  logger.error("db integrity failed; entering readonly mode", payload);
-  void sendAlertBestEffort({
-    severity: "critical",
-    trigger: "db_corrupted",
-    cooldownKey: "db_corrupted",
-    payload,
-  });
-  throw new Error(
-    `db integrity failed (integrity_check=${report.integrityCheck}, quick_check=${report.quickCheck}, fk=${report.foreignKeyViolations.length})`,
-  );
+	logger.error("db integrity failed; entering readonly mode", payload);
+	void sendAlertBestEffort({
+		severity: "critical",
+		trigger: "db_corrupted",
+		cooldownKey: "db_corrupted",
+		payload,
+	});
+	throw new Error(
+		`db integrity failed (integrity_check=${report.integrityCheck}, quick_check=${report.quickCheck}, fk=${report.foreignKeyViolations.length})`,
+	);
 }
 
-export async function runProcessLoop(deps: RunnerDeps, maxTasks: number): Promise<LoopResult> {
-  let processed = 0;
-  while (processed < maxTasks) {
-    const result = await processNextPending(deps);
-    if (result === null) return { processed, exitReason: "empty" };
-    if (result.agentResult.stopReason === "deferred") {
-      return { processed, exitReason: "deferred" };
-    }
-    processed += 1;
-  }
-  return { processed, exitReason: "max_tasks" };
+export async function runProcessLoop(
+	deps: RunnerDeps,
+	maxTasks: number,
+	onResult?: (result: ProcessResult) => Promise<void>,
+): Promise<LoopResult> {
+	let processed = 0;
+	while (processed < maxTasks) {
+		const result = await processNextPending(deps);
+		if (result === null) return { processed, exitReason: "empty" };
+		if (result.agentResult.stopReason === "deferred") {
+			return { processed, exitReason: "deferred" };
+		}
+		if (onResult !== undefined) {
+			await onResult(result);
+		}
+		processed += 1;
+	}
+	return { processed, exitReason: "max_tasks" };
 }
 
 export async function bootstrap(
-  argv: ReadonlyArray<string> = process.argv.slice(2),
+	argv: ReadonlyArray<string> = process.argv.slice(2),
 ): Promise<void> {
-  const config = loadConfig();
-  setMinLevel(config.clawde.log_level);
-  const logger = createLogger({ service: "worker" });
-  const dbPath = join(expandHome(config.clawde.home), "state.db");
-  const db = openDb(dbPath);
-  try {
-    applyPending(db, defaultMigrationsDir());
-    assertStartupDbIntegrity(db, logger);
-    const tasksRepo = new TasksRepo(db);
-    const runsRepo = new TaskRunsRepo(db);
-    const eventsRepo = new EventsRepo(db);
-    const quotaTracker = new QuotaTracker(new QuotaLedgerRepo(db));
-    const quotaPolicy = makeQuotaPolicy();
-    const leaseManager = new LeaseManager(runsRepo, eventsRepo, {
-      leaseSeconds: config.worker.lease_seconds,
-      heartbeatSeconds: config.worker.heartbeat_seconds,
-    });
-    const reconciler = makeReconciler(runsRepo, eventsRepo, {
-      tasksRepo,
-      workspaceTmpRoot: "/tmp",
-    });
-    const agentsRoot = join(expandHome(config.clawde.home), "agents");
-    const agentDefs = (() => {
-      try {
-        return loadAllAgentDefinitionsWithWarnings(agentsRoot, {
-          onWarning: (warning) => {
-            if (warning.kind === "bash_disallowed_by_sandbox_level") {
-              logger.warn("agent policy mismatch: Bash will be blocked at runtime", {
-                agent: warning.agentName,
-                sandbox_level: warning.sandboxLevel,
-                hint: "Set sandbox level to 1 or remove Bash from allowedTools (ADR 0015 / T-050).",
-              });
-            }
-          },
-        });
-      } catch (err) {
-        if (err instanceof AgentDefinitionError) {
-          const agentName = basename(dirname(err.agentPath));
-          throw new Error(`agent ${agentName} invalid: ${err.message}`);
-        }
-        throw err;
-      }
-    })();
-    const agentDefByName = new Map(agentDefs.map((d) => [d.name, d] as const));
-    const agentClient = new RealAgentClient();
-    const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
-    const reconcileResult = reconciler.reconcile(workerId);
-    logger.info("startup reconcile", {
-      expired_count: reconcileResult.expired.length,
-      reenqueued_count: reconcileResult.reenqueued.length,
-      cleaned_orphans: reconcileResult.cleanedOrphans,
-    });
-    const maxTasks = parseMaxTasks(argv);
-    const dryRun = parseDryRun(argv);
-    const queueSize = tasksRepo.findPending(1000).length;
-    const quotaState = quotaTracker.currentWindow().state;
-    logger.info("worker bootstrap state", {
-      dry_run: dryRun,
-      agents_loaded: agentDefs.length,
-      queue_size: queueSize,
-      quota_state: quotaState,
-    });
+	const config = loadConfig();
+	setMinLevel(config.clawde.log_level);
+	const logger = createLogger({ service: "worker" });
+	const dbPath = join(expandHome(config.clawde.home), "state.db");
+	const db = openDb(dbPath);
+	try {
+		applyPending(db, defaultMigrationsDir());
+		assertStartupDbIntegrity(db, logger);
+		const tasksRepo = new TasksRepo(db);
+		const runsRepo = new TaskRunsRepo(db);
+		const eventsRepo = new EventsRepo(db);
+		const quotaTracker = new QuotaTracker(new QuotaLedgerRepo(db));
+		const quotaPolicy = makeQuotaPolicy();
+		const leaseManager = new LeaseManager(runsRepo, eventsRepo, {
+			leaseSeconds: config.worker.lease_seconds,
+			heartbeatSeconds: config.worker.heartbeat_seconds,
+		});
+		const reconciler = makeReconciler(runsRepo, eventsRepo, {
+			tasksRepo,
+			workspaceTmpRoot: "/tmp",
+		});
+		const agentsRoot = join(expandHome(config.clawde.home), "agents");
+		const agentDefs = (() => {
+			try {
+				return loadAllAgentDefinitionsWithWarnings(agentsRoot, {
+					onWarning: (warning) => {
+						if (warning.kind === "bash_disallowed_by_sandbox_level") {
+							logger.warn(
+								"agent policy mismatch: Bash will be blocked at runtime",
+								{
+									agent: warning.agentName,
+									sandbox_level: warning.sandboxLevel,
+									hint: "Set sandbox level to 1 or remove Bash from allowedTools (ADR 0015 / T-050).",
+								},
+							);
+						}
+					},
+				});
+			} catch (err) {
+				if (err instanceof AgentDefinitionError) {
+					const agentName = basename(dirname(err.agentPath));
+					throw new Error(`agent ${agentName} invalid: ${err.message}`);
+				}
+				throw err;
+			}
+		})();
+		const agentDefByName = new Map(agentDefs.map((d) => [d.name, d] as const));
+		const agentClient = new RealAgentClient();
+		const workerId = `${hostname()}-${process.pid}-${Date.now()}`;
+		const reconcileResult = reconciler.reconcile(workerId);
+		logger.info("startup reconcile", {
+			expired_count: reconcileResult.expired.length,
+			reenqueued_count: reconcileResult.reenqueued.length,
+			cleaned_orphans: reconcileResult.cleanedOrphans,
+		});
+		const maxTasks = parseMaxTasks(argv);
+		const dryRun = parseDryRun(argv);
+		const queueSize = tasksRepo.findPending(1000).length;
+		const quotaState = quotaTracker.currentWindow().state;
+		logger.info("worker bootstrap state", {
+			dry_run: dryRun,
+			agents_loaded: agentDefs.length,
+			queue_size: queueSize,
+			quota_state: quotaState,
+		});
 
-    if (dryRun) {
-      logger.info("worker dry-run complete", {
-        agents_loaded: agentDefs.length,
-        queue_size: queueSize,
-        quota_state: quotaState,
-      });
-      return;
-    }
+		if (dryRun) {
+			logger.info("worker dry-run complete", {
+				agents_loaded: agentDefs.length,
+				queue_size: queueSize,
+				quota_state: quotaState,
+			});
+			return;
+		}
 
-    const loop = await runProcessLoop(
-      {
-        tasksRepo,
-        runsRepo,
-        eventsRepo,
-        leaseManager,
-        quotaTracker,
-        quotaPolicy,
-        agentClient,
-        logger,
-        workerId,
-        workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
-        resolveAgentDefinition: async (agent) => agentDefByName.get(agent) ?? null,
-      },
-      maxTasks,
-    );
-    logger.info("worker idle", {
-      processed: loop.processed,
-      max_tasks: maxTasks,
-      exit_reason: loop.exitReason,
-    });
-  } finally {
-    closeDb(db);
-  }
+		const loop = await runProcessLoop(
+			{
+				tasksRepo,
+				runsRepo,
+				eventsRepo,
+				leaseManager,
+				quotaTracker,
+				quotaPolicy,
+				agentClient,
+				logger,
+				workerId,
+				workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
+				resolveAgentDefinition: async (agent) =>
+					agentDefByName.get(agent) ?? null,
+			},
+			maxTasks,
+			(result) => sendTelegramReply(result.task, result.agentResult, logger),
+		);
+		logger.info("worker idle", {
+			processed: loop.processed,
+			max_tasks: maxTasks,
+			exit_reason: loop.exitReason,
+		});
+	} finally {
+		closeDb(db);
+	}
 }
 
 if (import.meta.main) {
-  bootstrap()
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error((err as Error).message);
-      process.exit(1);
-    });
+	bootstrap()
+		.then(() => process.exit(0))
+		.catch((err) => {
+			console.error((err as Error).message);
+			process.exit(1);
+		});
 }

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -19,6 +19,7 @@ import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
 import { TasksRepo } from "@clawde/db/repositories/tasks";
 import { createLogger, setMinLevel } from "@clawde/log";
 import { makeQuotaPolicy, QuotaTracker } from "@clawde/quota";
+import { runReviewPipeline } from "@clawde/review";
 import { RealAgentClient } from "@clawde/sdk";
 import {
 	LeaseManager,
@@ -205,6 +206,17 @@ export async function bootstrap(
 			return;
 		}
 
+		const reviewDeps: import("./runner.ts").ReviewPipelineDeps | undefined =
+			config.review?.review_required === true
+				? {
+						config: {
+							stages: config.review.stages as import("@clawde/review").ReviewRole[],
+							maxRetriesPerStage: config.review.max_retries_per_stage,
+						},
+						run: runReviewPipeline,
+					}
+				: undefined;
+
 		const loop = await runProcessLoop(
 			{
 				tasksRepo,
@@ -219,6 +231,7 @@ export async function bootstrap(
 				workspaceConfig: { tmpRoot: "/tmp", baseBranch: "main" },
 				resolveAgentDefinition: async (agent) =>
 					agentDefByName.get(agent) ?? null,
+				...(reviewDeps !== undefined ? { review: reviewDeps } : {}),
 			},
 			maxTasks,
 			(result) => sendTelegramReply(result.task, result.agentResult, logger),

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -13,9 +13,9 @@
  */
 
 import {
-  type SetupTokenRunner,
-  invokeWithAutoRefresh,
-  spawnClaudeSetupToken,
+	invokeWithAutoRefresh,
+	type SetupTokenRunner,
+	spawnClaudeSetupToken,
 } from "@clawde/auth/refresh";
 import type { EventsRepo } from "@clawde/db/repositories/events";
 import type { MemoryRepo } from "@clawde/db/repositories/memory";
@@ -24,83 +24,91 @@ import type { TasksRepo } from "@clawde/db/repositories/tasks";
 import type { QuotaPolicy } from "@clawde/domain/quota";
 import { deriveSessionId } from "@clawde/domain/session";
 import type { Task, TaskRun, TaskSource } from "@clawde/domain/task";
-import { type PreToolUsePayload, makePreToolUseHandler } from "@clawde/hooks";
+import { makePreToolUseHandler, type PreToolUsePayload } from "@clawde/hooks";
 import type { Logger } from "@clawde/log";
-import type { MemoryAwareConfig, buildMemoryContext as buildMemoryContextFn } from "@clawde/memory";
+import type {
+	buildMemoryContext as buildMemoryContextFn,
+	MemoryAwareConfig,
+} from "@clawde/memory";
 import type { QuotaTracker } from "@clawde/quota";
-import type { PipelineConfig, runReviewPipeline as runReviewPipelineFn } from "@clawde/review";
+import type {
+	PipelineConfig,
+	runReviewPipeline as runReviewPipelineFn,
+} from "@clawde/review";
+import {
+	isBwrapAvailable,
+	makeSandboxedClaudeWrapper,
+	type SandboxedWrapper,
+} from "@clawde/sandbox";
 import { composeAppendSystemPrompt } from "@clawde/sanitize";
 import {
-  isBwrapAvailable,
-  makeSandboxedClaudeWrapper,
-  type SandboxedWrapper,
-} from "@clawde/sandbox";
-import {
-  type AgentClient,
-  type AgentRunResult,
-  SdkAuthError,
-  SdkNetworkError,
-  SdkRateLimitError,
+	type AgentClient,
+	type AgentRunResult,
+	SdkAuthError,
+	SdkNetworkError,
+	SdkRateLimitError,
 } from "@clawde/sdk";
 import type { LeaseManager } from "./lease.ts";
 import {
-  type AgentDefinitionLike,
-  createWorkspace,
-  removeWorkspace,
-  shouldUseEphemeralWorkspace,
+	type AgentDefinitionLike,
+	createWorkspace,
+	removeWorkspace,
+	shouldUseEphemeralWorkspace,
 } from "./workspace.ts";
 
 export interface MemoryInjectDeps {
-  readonly memoryRepo: MemoryRepo;
-  readonly config: MemoryAwareConfig;
-  readonly buildContext: typeof buildMemoryContextFn;
+	readonly memoryRepo: MemoryRepo;
+	readonly config: MemoryAwareConfig;
+	readonly buildContext: typeof buildMemoryContextFn;
 }
 
 export interface ReviewPipelineDeps {
-  readonly config: PipelineConfig;
-  readonly run: typeof runReviewPipelineFn;
+	readonly config: PipelineConfig;
+	readonly run: typeof runReviewPipelineFn;
 }
 
 export interface RunnerDeps {
-  readonly tasksRepo: TasksRepo;
-  readonly runsRepo: TaskRunsRepo;
-  readonly eventsRepo: EventsRepo;
-  readonly leaseManager: LeaseManager;
-  readonly quotaTracker: QuotaTracker;
-  readonly quotaPolicy: QuotaPolicy;
-  readonly agentClient: AgentClient;
-  readonly logger: Logger;
-  readonly workerId: string;
-  readonly workspaceConfig?: { tmpRoot: string; baseBranch: string };
-  readonly resolveAgentDefinition?: (agent: string) => Promise<AgentDefinitionLike | null>;
-  /** Overrides para fluxo de auto-refresh em testes. */
-  readonly authRefresh?: {
-    readonly runSetupToken?: SetupTokenRunner;
-    readonly reloadToken?: () => {
-      value: string;
-      source: "systemd-credential" | "keychain" | "env";
-    };
-  };
-  /** Opt-in: injeta memory context antes do prompt. */
-  readonly memoryInject?: MemoryInjectDeps;
-  /** Opt-in: roda review pipeline ao invés de invocação simples. */
-  readonly review?: ReviewPipelineDeps;
+	readonly tasksRepo: TasksRepo;
+	readonly runsRepo: TaskRunsRepo;
+	readonly eventsRepo: EventsRepo;
+	readonly leaseManager: LeaseManager;
+	readonly quotaTracker: QuotaTracker;
+	readonly quotaPolicy: QuotaPolicy;
+	readonly agentClient: AgentClient;
+	readonly logger: Logger;
+	readonly workerId: string;
+	readonly workspaceConfig?: { tmpRoot: string; baseBranch: string };
+	readonly resolveAgentDefinition?: (
+		agent: string,
+	) => Promise<AgentDefinitionLike | null>;
+	/** Overrides para fluxo de auto-refresh em testes. */
+	readonly authRefresh?: {
+		readonly runSetupToken?: SetupTokenRunner;
+		readonly reloadToken?: () => {
+			value: string;
+			source: "systemd-credential" | "keychain" | "env";
+		};
+	};
+	/** Opt-in: injeta memory context antes do prompt. */
+	readonly memoryInject?: MemoryInjectDeps;
+	/** Opt-in: roda review pipeline ao invés de invocação simples. */
+	readonly review?: ReviewPipelineDeps;
 }
 
 export interface ProcessResult {
-  readonly task: Task;
-  readonly run: TaskRun;
-  readonly agentResult: AgentRunResult;
+	readonly task: Task;
+	readonly run: TaskRun;
+	readonly agentResult: AgentRunResult;
 }
 
 class LeaseBusyError extends Error {
-  constructor(
-    readonly taskId: number,
-    readonly taskRunId: number,
-  ) {
-    super(`lease busy for task ${taskId} run ${taskRunId}`);
-    this.name = "LeaseBusyError";
-  }
+	constructor(
+		readonly taskId: number,
+		readonly taskRunId: number,
+	) {
+		super(`lease busy for task ${taskId} run ${taskRunId}`);
+		this.name = "LeaseBusyError";
+	}
 }
 
 /**
@@ -112,7 +120,7 @@ class LeaseBusyError extends Error {
 const TRUSTED_SOURCES: ReadonlySet<TaskSource> = new Set(["cli", "subagent"]);
 
 function isExternalSource(source: TaskSource): boolean {
-  return !TRUSTED_SOURCES.has(source);
+	return !TRUSTED_SOURCES.has(source);
 }
 
 /**
@@ -122,436 +130,462 @@ function isExternalSource(source: TaskSource): boolean {
  *   - invoke agent → stream messages, decrementar ledger
  *   - finish (succeeded/failed) → events.task_finish/task_fail
  */
-export async function processTask(deps: RunnerDeps, task: Task): Promise<ProcessResult> {
-  const log = deps.logger.child({ taskId: task.id });
-  log.info("task processing", { agent: task.agent, priority: task.priority });
+export async function processTask(
+	deps: RunnerDeps,
+	task: Task,
+): Promise<ProcessResult> {
+	const log = deps.logger.child({ taskId: task.id });
+	log.info("task processing", { agent: task.agent, priority: task.priority });
 
-  const quotaWindow = deps.quotaTracker.currentWindow();
-  const quotaDecision = deps.quotaPolicy.canAccept(quotaWindow, task.priority);
+	const quotaWindow = deps.quotaTracker.currentWindow();
+	const quotaDecision = deps.quotaPolicy.canAccept(quotaWindow, task.priority);
 
-  const latest = deps.runsRepo.findLatestByTaskId(task.id);
-  let run: TaskRun;
-  if (latest === null) {
-    run = deps.runsRepo.insert(task.id, deps.workerId);
-  } else if (latest.status === "pending") {
-    run = latest;
-  } else {
-    throw new LeaseBusyError(task.id, latest.id);
-  }
+	const latest = deps.runsRepo.findLatestByTaskId(task.id);
+	let run: TaskRun;
+	if (latest === null) {
+		run = deps.runsRepo.insert(task.id, deps.workerId);
+	} else if (latest.status === "pending") {
+		run = latest;
+	} else {
+		throw new LeaseBusyError(task.id, latest.id);
+	}
 
-  if (!quotaDecision.accept) {
-    if (quotaDecision.deferUntil !== null) {
-      const previousNotBefore = run.notBefore;
-      run = deps.runsRepo.setNotBefore(run.id, quotaDecision.deferUntil);
-      if (previousNotBefore !== quotaDecision.deferUntil) {
-        deps.eventsRepo.insert({
-          taskRunId: run.id,
-          sessionId: task.sessionId,
-          traceId: null,
-          spanId: null,
-          kind: "task_deferred",
-          payload: {
-            task_id: task.id,
-            priority: task.priority,
-            state: quotaWindow.state,
-            defer_until: quotaDecision.deferUntil,
-            reason: quotaDecision.reason,
-          },
-        });
-      }
-    }
+	if (!quotaDecision.accept) {
+		if (quotaDecision.deferUntil !== null) {
+			const previousNotBefore = run.notBefore;
+			run = deps.runsRepo.setNotBefore(run.id, quotaDecision.deferUntil);
+			if (previousNotBefore !== quotaDecision.deferUntil) {
+				deps.eventsRepo.insert({
+					taskRunId: run.id,
+					sessionId: task.sessionId,
+					traceId: null,
+					spanId: null,
+					kind: "task_deferred",
+					payload: {
+						task_id: task.id,
+						priority: task.priority,
+						state: quotaWindow.state,
+						defer_until: quotaDecision.deferUntil,
+						reason: quotaDecision.reason,
+					},
+				});
+			}
+		}
 
-    log.info("task deferred by quota policy", {
-      state: quotaWindow.state,
-      defer_until: quotaDecision.deferUntil,
-    });
-    return {
-      task,
-      run,
-      agentResult: {
-        stopReason: "deferred",
-        msgsConsumed: 0,
-        totalTurns: 0,
-        finalText: "",
-        error: null,
-      },
-    };
-  }
+		log.info("task deferred by quota policy", {
+			state: quotaWindow.state,
+			defer_until: quotaDecision.deferUntil,
+		});
+		return {
+			task,
+			run,
+			agentResult: {
+				stopReason: "deferred",
+				msgsConsumed: 0,
+				totalTurns: 0,
+				finalText: "",
+				error: null,
+			},
+		};
+	}
 
-  const acquisition = deps.leaseManager.acquire(run.id);
-  if (acquisition === null) {
-    throw new LeaseBusyError(task.id, run.id);
-  }
+	const acquisition = deps.leaseManager.acquire(run.id);
+	if (acquisition === null) {
+		throw new LeaseBusyError(task.id, run.id);
+	}
 
-  const workspaceConfig = deps.workspaceConfig ?? { tmpRoot: "/tmp", baseBranch: "main" };
-  let agentDef: AgentDefinitionLike | null = null;
-  if (deps.resolveAgentDefinition !== undefined) {
-    agentDef = await deps.resolveAgentDefinition(task.agent);
-    if (agentDef === null) {
-      throw new Error(`agent '${task.agent}' not found in AGENT.md definitions`);
-    }
-  }
-  let ephemeralWorkspacePath: string | null = null;
-  if (task.workingDir !== null && agentDef !== null) {
-    if (shouldUseEphemeralWorkspace(task, agentDef)) {
-      const ws = await createWorkspace({
-        taskRunId: run.id,
-        taskId: task.id,
-        slug: task.prompt.slice(0, 40),
-        baseBranch: workspaceConfig.baseBranch,
-        repoRoot: task.workingDir,
-        tmpRoot: workspaceConfig.tmpRoot,
-      });
-      ephemeralWorkspacePath = ws.path;
-    }
-  }
+	const workspaceConfig = deps.workspaceConfig ?? {
+		tmpRoot: "/tmp",
+		baseBranch: "main",
+	};
+	let agentDef: AgentDefinitionLike | null = null;
+	if (deps.resolveAgentDefinition !== undefined) {
+		agentDef = await deps.resolveAgentDefinition(task.agent);
+		if (agentDef === null) {
+			throw new Error(
+				`agent '${task.agent}' not found in AGENT.md definitions`,
+			);
+		}
+	}
+	let ephemeralWorkspacePath: string | null = null;
+	if (task.workingDir !== null && agentDef !== null) {
+		if (shouldUseEphemeralWorkspace(task, agentDef)) {
+			const ws = await createWorkspace({
+				taskRunId: run.id,
+				taskId: task.id,
+				slug: task.prompt.slice(0, 40),
+				baseBranch: workspaceConfig.baseBranch,
+				repoRoot: task.workingDir,
+				tmpRoot: workspaceConfig.tmpRoot,
+			});
+			ephemeralWorkspacePath = ws.path;
+		}
+	}
 
-  try {
-    // T-055: prior_context (memory) é tratado como SYSTEM PROMPT confiável,
-    // não como user content. Capturamos o snippet aqui mas a injeção é via
-    // `composeAppendSystemPrompt` lá embaixo (no streamOpts), separando-o do
-    // user-provided external input que continua dentro de `<external_input>`
-    // no user prompt.
-    const effectivePrompt = task.prompt;
-    let memorySnippet: string | null = null;
-    if (deps.memoryInject?.config.enabled) {
-      try {
-        const ctx = await deps.memoryInject.buildContext(
-          deps.memoryInject.memoryRepo,
-          task.prompt,
-          deps.memoryInject.config,
-        );
-        if (ctx.injected) {
-          memorySnippet = ctx.snippet;
-        }
-      } catch (err) {
-        log.warn("memory inject failed (continuing without)", { error: (err as Error).message });
-      }
-    }
+	try {
+		// T-055: prior_context (memory) é tratado como SYSTEM PROMPT confiável,
+		// não como user content. Capturamos o snippet aqui mas a injeção é via
+		// `composeAppendSystemPrompt` lá embaixo (no streamOpts), separando-o do
+		// user-provided external input que continua dentro de `<external_input>`
+		// no user prompt.
+		const effectivePrompt = task.prompt;
+		let memorySnippet: string | null = null;
+		if (deps.memoryInject?.config.enabled) {
+			try {
+				const ctx = await deps.memoryInject.buildContext(
+					deps.memoryInject.memoryRepo,
+					task.prompt,
+					deps.memoryInject.config,
+				);
+				if (ctx.injected) {
+					memorySnippet = ctx.snippet;
+				}
+			} catch (err) {
+				log.warn("memory inject failed (continuing without)", {
+					error: (err as Error).message,
+				});
+			}
+		}
 
-    // Emite invocation_start.
-    deps.eventsRepo.insert({
-      taskRunId: run.id,
-      sessionId: task.sessionId,
-      traceId: null,
-      spanId: null,
-      kind: "claude_invocation_start",
-      payload: { agent: task.agent, prompt_len: effectivePrompt.length },
-    });
+		// Emite invocation_start.
+		deps.eventsRepo.insert({
+			taskRunId: run.id,
+			sessionId: task.sessionId,
+			traceId: null,
+			spanId: null,
+			kind: "claude_invocation_start",
+			payload: { agent: task.agent, prompt_len: effectivePrompt.length },
+		});
 
-    let agentResult: AgentRunResult;
-    try {
-      agentResult =
-        deps.review !== undefined
-          ? await runWithReviewPipeline(
-              deps,
-              task,
-              run.id,
-              run.attemptN,
-              effectivePrompt,
-              ephemeralWorkspacePath,
-              agentDef,
-              memorySnippet,
-            )
-          : await runAgentWithLedger(
-              deps,
-              task,
-              run.id,
-              effectivePrompt,
-              ephemeralWorkspacePath,
-              agentDef,
-              memorySnippet,
-            );
-    } catch (err) {
-      if (err instanceof SdkRateLimitError) {
-        deps.quotaTracker.markCurrentWindowExhausted();
-        const exhaustedWindow = deps.quotaTracker.currentWindow();
-        const failed = deps.leaseManager.finish(acquisition, "failed", {
-          error: err.message,
-        });
-        const deferred = deps.runsRepo.insert(task.id, deps.workerId, {
-          notBefore: exhaustedWindow.resetsAt,
-        });
-        deps.eventsRepo.insert({
-          taskRunId: failed.id,
-          sessionId: task.sessionId,
-          traceId: null,
-          spanId: null,
-          kind: "quota_429_observed",
-          payload: {
-            task_id: task.id,
-            failed_run_id: failed.id,
-            deferred_run_id: deferred.id,
-            retry_after_seconds: err.retryAfterSeconds,
-            defer_until: exhaustedWindow.resetsAt,
-          },
-        });
-        return {
-          task,
-          run: deferred,
-          agentResult: {
-            stopReason: "error",
-            msgsConsumed: 0,
-            totalTurns: 0,
-            finalText: "",
-            error: err.message,
-          },
-        };
-      }
+		let agentResult: AgentRunResult;
+		try {
+			agentResult =
+				deps.review !== undefined
+					? await runWithReviewPipeline(
+							deps,
+							task,
+							run.id,
+							run.attemptN,
+							effectivePrompt,
+							ephemeralWorkspacePath,
+							agentDef,
+							memorySnippet,
+						)
+					: await runAgentWithLedger(
+							deps,
+							task,
+							run.id,
+							effectivePrompt,
+							ephemeralWorkspacePath,
+							agentDef,
+							memorySnippet,
+						);
+		} catch (err) {
+			if (err instanceof SdkRateLimitError) {
+				deps.quotaTracker.markCurrentWindowExhausted();
+				const exhaustedWindow = deps.quotaTracker.currentWindow();
+				const failed = deps.leaseManager.finish(acquisition, "failed", {
+					error: err.message,
+				});
+				const deferred = deps.runsRepo.insert(task.id, deps.workerId, {
+					notBefore: exhaustedWindow.resetsAt,
+				});
+				deps.eventsRepo.insert({
+					taskRunId: failed.id,
+					sessionId: task.sessionId,
+					traceId: null,
+					spanId: null,
+					kind: "quota_429_observed",
+					payload: {
+						task_id: task.id,
+						failed_run_id: failed.id,
+						deferred_run_id: deferred.id,
+						retry_after_seconds: err.retryAfterSeconds,
+						defer_until: exhaustedWindow.resetsAt,
+					},
+				});
+				return {
+					task,
+					run: deferred,
+					agentResult: {
+						stopReason: "error",
+						msgsConsumed: 0,
+						totalTurns: 0,
+						finalText: "",
+						error: err.message,
+					},
+				};
+			}
 
-      log.error("agent invocation crashed", { error: (err as Error).message });
-      const finished = deps.leaseManager.finish(acquisition, "failed", {
-        error: (err as Error).message,
-      });
-      return {
-        task,
-        run: finished,
-        agentResult: {
-          stopReason: "error",
-          msgsConsumed: 0,
-          totalTurns: 0,
-          finalText: "",
-          error: (err as Error).message,
-        },
-      };
-    }
+			log.error("agent invocation crashed", { error: (err as Error).message });
+			const finished = deps.leaseManager.finish(acquisition, "failed", {
+				error: (err as Error).message,
+			});
+			return {
+				task,
+				run: finished,
+				agentResult: {
+					stopReason: "error",
+					msgsConsumed: 0,
+					totalTurns: 0,
+					finalText: "",
+					error: (err as Error).message,
+				},
+			};
+		}
 
-    // Emite invocation_end.
-    deps.eventsRepo.insert({
-      taskRunId: run.id,
-      sessionId: task.sessionId,
-      traceId: null,
-      spanId: null,
-      kind: "claude_invocation_end",
-      payload: {
-        stop_reason: agentResult.stopReason,
-        msgs_consumed: agentResult.msgsConsumed,
-        total_turns: agentResult.totalTurns,
-      },
-    });
+		// Emite invocation_end.
+		deps.eventsRepo.insert({
+			taskRunId: run.id,
+			sessionId: task.sessionId,
+			traceId: null,
+			spanId: null,
+			kind: "claude_invocation_end",
+			payload: {
+				stop_reason: agentResult.stopReason,
+				msgs_consumed: agentResult.msgsConsumed,
+				total_turns: agentResult.totalTurns,
+			},
+		});
 
-    const finalStatus = agentResult.error === null ? "succeeded" : "failed";
-    const finished = deps.leaseManager.finish(acquisition, finalStatus, {
-      result: agentResult.finalText.length > 0 ? agentResult.finalText : null,
-      error: agentResult.error,
-      msgsConsumed: agentResult.msgsConsumed,
-    } as { result?: string; error?: string; msgsConsumed?: number });
+		const finalStatus = agentResult.error === null ? "succeeded" : "failed";
+		const finished = deps.leaseManager.finish(acquisition, finalStatus, {
+			result: agentResult.finalText.length > 0 ? agentResult.finalText : null,
+			error: agentResult.error,
+			msgsConsumed: agentResult.msgsConsumed,
+		} as { result?: string; error?: string; msgsConsumed?: number });
 
-    log.info("task finished", { status: finalStatus, msgs: agentResult.msgsConsumed });
-    return { task, run: finished, agentResult };
-  } finally {
-    if (ephemeralWorkspacePath !== null && task.workingDir !== null) {
-      try {
-        await removeWorkspace(
-          {
-            path: ephemeralWorkspacePath,
-            baseBranch: workspaceConfig.baseBranch,
-            featureBranch: "",
-            taskRunId: run.id,
-            createdAt: "",
-          },
-          task.workingDir,
-        );
-      } catch (err) {
-        log.warn("workspace cleanup failed", {
-          error: (err as Error).message,
-          path: ephemeralWorkspacePath,
-        });
-      }
-    }
-  }
+		log.info("task finished", {
+			status: finalStatus,
+			msgs: agentResult.msgsConsumed,
+		});
+		return { task, run: finished, agentResult };
+	} finally {
+		if (ephemeralWorkspacePath !== null && task.workingDir !== null) {
+			try {
+				await removeWorkspace(
+					{
+						path: ephemeralWorkspacePath,
+						baseBranch: workspaceConfig.baseBranch,
+						featureBranch: "",
+						taskRunId: run.id,
+						createdAt: "",
+					},
+					task.workingDir,
+				);
+			} catch (err) {
+				log.warn("workspace cleanup failed", {
+					error: (err as Error).message,
+					path: ephemeralWorkspacePath,
+				});
+			}
+		}
+	}
 }
 
 /**
  * Itera pela próxima task pending e processa. Loop único — chamador (worker main)
  * decide quantas processar por invocação.
  */
-export async function processNextPending(deps: RunnerDeps): Promise<ProcessResult | null> {
-  const pending = deps.tasksRepo.findPending(1);
-  if (pending.length === 0) return null;
-  const task = pending[0];
-  if (task === undefined) return null;
-  try {
-    return await processTask(deps, task);
-  } catch (err) {
-    if (err instanceof LeaseBusyError) return null;
-    throw err;
-  }
+export async function processNextPending(
+	deps: RunnerDeps,
+): Promise<ProcessResult | null> {
+	const pending = deps.tasksRepo.findPending(1);
+	if (pending.length === 0) return null;
+	const task = pending[0];
+	if (task === undefined) return null;
+	try {
+		return await processTask(deps, task);
+	} catch (err) {
+		if (err instanceof LeaseBusyError) return null;
+		throw err;
+	}
 }
 
 async function runAgentWithLedger(
-  deps: RunnerDeps,
-  task: Task,
-  taskRunId: number,
-  effectivePrompt: string,
-  workingDirectoryOverride: string | null,
-  agentDef: AgentDefinitionLike | null,
-  memorySnippet: string | null,
+	deps: RunnerDeps,
+	task: Task,
+	taskRunId: number,
+	effectivePrompt: string,
+	workingDirectoryOverride: string | null,
+	agentDef: AgentDefinitionLike | null,
+	memorySnippet: string | null,
 ): Promise<AgentRunResult> {
-  const AUTH_RETRY_TOKEN = { value: "worker-auth-retry", source: "env" as const };
+	const AUTH_RETRY_TOKEN = {
+		value: "worker-auth-retry",
+		source: "env" as const,
+	};
 
-  let msgsConsumed = 0;
-  let totalTurns = 0;
-  const textParts: string[] = [];
-  let lastRole: string | null = null;
-  let stopReason: AgentRunResult["stopReason"] = "completed";
-  let error: string | null = null;
+	let msgsConsumed = 0;
+	let totalTurns = 0;
+	const textParts: string[] = [];
+	let lastRole: string | null = null;
+	let stopReason: AgentRunResult["stopReason"] = "completed";
+	let error: string | null = null;
 
-  const streamOpts: {
-    prompt: string;
-    sessionId?: string;
-    workingDirectory?: string;
-    appendSystemPrompt?: string;
-    allowedTools?: ReadonlyArray<string>;
-    disallowedTools?: ReadonlyArray<string>;
-    maxTurns?: number;
-    claudeExecutablePath?: string;
-  } = {
-    prompt: effectivePrompt,
-  };
-  const allowedTools = agentDef?.frontmatter?.allowedTools ?? [];
-  const disallowedTools = new Set(agentDef?.frontmatter?.disallowedTools ?? []);
-  const sandboxLevel = agentDef?.sandbox?.level ?? 1;
-  if (sandboxLevel >= 2) {
-    disallowedTools.add("Bash");
-  }
+	const streamOpts: {
+		prompt: string;
+		sessionId?: string;
+		workingDirectory?: string;
+		appendSystemPrompt?: string;
+		allowedTools?: ReadonlyArray<string>;
+		disallowedTools?: ReadonlyArray<string>;
+		maxTurns?: number;
+		claudeExecutablePath?: string;
+	} = {
+		prompt: effectivePrompt,
+	};
+	const allowedTools = agentDef?.frontmatter?.allowedTools ?? [];
+	const disallowedTools = new Set(agentDef?.frontmatter?.disallowedTools ?? []);
+	const sandboxLevel = agentDef?.sandbox?.level ?? 1;
+	if (sandboxLevel >= 2) {
+		disallowedTools.add("Bash");
+	}
 
-  // OS-level filesystem sandbox for level >= 2 agents via bwrap.
-  let sandboxWrapper: SandboxedWrapper | null = null;
-  if (sandboxLevel >= 2 && isBwrapAvailable()) {
-    try {
-      sandboxWrapper = makeSandboxedClaudeWrapper(
-        task.agent,
-        agentDef?.sandbox?.read_only_mounts ?? [],
-        process.env as Record<string, string | undefined>,
-      );
-      streamOpts.claudeExecutablePath = sandboxWrapper.wrapperPath;
-    } catch (err) {
-      deps.logger.warn("bwrap wrapper creation failed, running unsandboxed", {
-        agent: task.agent,
-        error: (err as Error).message,
-      });
-    }
-  }
-  if (allowedTools.length > 0) streamOpts.allowedTools = allowedTools;
-  if (disallowedTools.size > 0) streamOpts.disallowedTools = [...disallowedTools];
-  if (agentDef?.frontmatter?.maxTurns !== undefined) {
-    streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
-  }
+	// OS-level filesystem sandbox for level >= 2 agents via bwrap.
+	let sandboxWrapper: SandboxedWrapper | null = null;
+	if (sandboxLevel >= 2 && isBwrapAvailable()) {
+		try {
+			sandboxWrapper = makeSandboxedClaudeWrapper(
+				task.agent,
+				agentDef?.sandbox?.read_only_mounts ?? [],
+				process.env as Record<string, string | undefined>,
+			);
+			streamOpts.claudeExecutablePath = sandboxWrapper.wrapperPath;
+		} catch (err) {
+			deps.logger.warn("bwrap wrapper creation failed, running unsandboxed", {
+				agent: task.agent,
+				error: (err as Error).message,
+			});
+		}
+	}
+	if (allowedTools.length > 0) streamOpts.allowedTools = allowedTools;
+	if (disallowedTools.size > 0)
+		streamOpts.disallowedTools = [...disallowedTools];
+	if (agentDef?.frontmatter?.maxTurns !== undefined) {
+		streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
+	}
 
-  // For level < 2 agents (no bwrap), sandbox.toml uses "/workspace" as a
-  // placeholder for the ephemeral worktree. Without bwrap there is no filesystem
-  // mapping, so resolve "/workspace" to the actual working directory (issue #51).
-  const rawAllowedWrites = agentDef?.sandbox?.allowed_writes ?? [];
-  const effectiveAllowedWrites =
-    sandboxLevel < 2 && workingDirectoryOverride !== null
-      ? rawAllowedWrites.map((w) => (w === "/workspace" ? workingDirectoryOverride : w))
-      : rawAllowedWrites;
+	// For level < 2 agents (no bwrap), sandbox.toml uses "/workspace" as a
+	// placeholder for the ephemeral worktree. Without bwrap there is no filesystem
+	// mapping, so resolve "/workspace" to the actual working directory (issue #51).
+	const rawAllowedWrites = agentDef?.sandbox?.allowed_writes ?? [];
+	const effectiveAllowedWrites =
+		sandboxLevel < 2 && workingDirectoryOverride !== null
+			? rawAllowedWrites.map((w) =>
+					w === "/workspace" ? workingDirectoryOverride : w,
+				)
+			: rawAllowedWrites;
 
-  const preToolHandler = makePreToolUseHandler(() => {}, {
-    allowedTools,
-    sandbox: {
-      level: agentDef?.sandbox?.level ?? 1,
-      allowed_writes: effectiveAllowedWrites,
-      // Propaga allowed_reads SOMENTE quando definido na config; senão deixa
-      // undefined (comportamento legacy permissivo) — `exactOptionalPropertyTypes`.
-      ...(agentDef?.sandbox?.allowed_reads !== undefined
-        ? { allowed_reads: agentDef.sandbox.allowed_reads }
-        : {}),
-      // cwd enables relative-path resolution in write/read checks (issue #51).
-      ...(workingDirectoryOverride !== null ? { cwd: workingDirectoryOverride } : {}),
-    },
-  });
-  if (task.sessionId !== null) streamOpts.sessionId = task.sessionId;
-  if (workingDirectoryOverride !== null) {
-    streamOpts.workingDirectory = workingDirectoryOverride;
-  } else if (task.workingDir !== null) {
-    streamOpts.workingDirectory = task.workingDir;
-  }
-  // T-054 + T-055: appendSystemPrompt compõe (sem sobrescrever):
-  //   EXTERNAL_INPUT_SYSTEM_PROMPT (quando source é externa)
-  //   + prior_context (memory snippet — sempre system prompt confiável).
-  // user prompt continua com o `<external_input>` envelope quando aplicável.
-  const appendSystem = composeAppendSystemPrompt({
-    externalInputSafety: isExternalSource(task.source),
-    ...(memorySnippet !== null ? { priorContext: memorySnippet } : {}),
-  });
-  if (appendSystem !== undefined) {
-    streamOpts.appendSystemPrompt = appendSystem;
-  }
+	const preToolHandler = makePreToolUseHandler(() => {}, {
+		allowedTools,
+		sandbox: {
+			level: agentDef?.sandbox?.level ?? 1,
+			allowed_writes: effectiveAllowedWrites,
+			// Propaga allowed_reads SOMENTE quando definido na config; senão deixa
+			// undefined (comportamento legacy permissivo) — `exactOptionalPropertyTypes`.
+			...(agentDef?.sandbox?.allowed_reads !== undefined
+				? { allowed_reads: agentDef.sandbox.allowed_reads }
+				: {}),
+			// cwd enables relative-path resolution in write/read checks (issue #51).
+			...(workingDirectoryOverride !== null
+				? { cwd: workingDirectoryOverride }
+				: {}),
+		},
+	});
+	if (task.sessionId !== null) streamOpts.sessionId = task.sessionId;
+	if (workingDirectoryOverride !== null) {
+		streamOpts.workingDirectory = workingDirectoryOverride;
+	} else if (task.workingDir !== null) {
+		streamOpts.workingDirectory = task.workingDir;
+	}
+	// T-054 + T-055: appendSystemPrompt compõe (sem sobrescrever):
+	//   EXTERNAL_INPUT_SYSTEM_PROMPT (quando source é externa)
+	//   + prior_context (memory snippet — sempre system prompt confiável).
+	// user prompt continua com o `<external_input>` envelope quando aplicável.
+	const appendSystem = composeAppendSystemPrompt({
+		externalInputSafety: isExternalSource(task.source),
+		...(memorySnippet !== null ? { priorContext: memorySnippet } : {}),
+	});
+	if (appendSystem !== undefined) {
+		streamOpts.appendSystemPrompt = appendSystem;
+	}
 
-  const runStreamOnce = async (): Promise<void> => {
-    for await (const msg of deps.agentClient.stream(streamOpts)) {
-      msgsConsumed += 1;
-      deps.quotaTracker.recordMessage(taskRunId);
-      if (msg.role === "assistant") {
-        if (lastRole !== "assistant") totalTurns += 1;
-        for (const b of msg.blocks) {
-          if (b.type === "text") {
-            textParts.push(b.text);
-            continue;
-          }
-          if (b.type === "tool_use") {
-            const maybeGate = preToolHandler({
-              hook: "PreToolUse",
-              sessionId: task.sessionId ?? "worker-session",
-              taskRunId,
-              ts: new Date().toISOString(),
-              payload: {
-                toolName: b.name,
-                toolInput: b.input as PreToolUsePayload["toolInput"],
-              },
-            });
-            const gate = maybeGate instanceof Promise ? await maybeGate : maybeGate;
-            if (!gate.ok && gate.block) {
-              throw new Error(gate.message ?? `tool '${b.name}' blocked by policy`);
-            }
-          }
-        }
-      }
-      lastRole = msg.role;
-    }
-  };
+	const runStreamOnce = async (): Promise<void> => {
+		for await (const msg of deps.agentClient.stream(streamOpts)) {
+			msgsConsumed += 1;
+			deps.quotaTracker.recordMessage(taskRunId);
+			if (msg.role === "assistant") {
+				if (lastRole !== "assistant") totalTurns += 1;
+				for (const b of msg.blocks) {
+					if (b.type === "text") {
+						textParts.push(b.text);
+						continue;
+					}
+					if (b.type === "tool_use") {
+						const maybeGate = preToolHandler({
+							hook: "PreToolUse",
+							sessionId: task.sessionId ?? "worker-session",
+							taskRunId,
+							ts: new Date().toISOString(),
+							payload: {
+								toolName: b.name,
+								toolInput: b.input as PreToolUsePayload["toolInput"],
+							},
+						});
+						const gate =
+							maybeGate instanceof Promise ? await maybeGate : maybeGate;
+						if (!gate.ok && gate.block) {
+							throw new Error(
+								gate.message ?? `tool '${b.name}' blocked by policy`,
+							);
+						}
+					}
+				}
+			}
+			lastRole = msg.role;
+		}
+	};
 
-  try {
-    await invokeWithAutoRefresh(
-      AUTH_RETRY_TOKEN,
-      async () => {
-        await runStreamOnce();
-      },
-      {
-        runSetupToken: deps.authRefresh?.runSetupToken ?? spawnClaudeSetupToken,
-        reloadToken: deps.authRefresh?.reloadToken ?? (() => AUTH_RETRY_TOKEN),
-      },
-    );
-  } catch (err) {
-    if (err instanceof SdkRateLimitError || err instanceof SdkNetworkError) {
-      throw err;
-    }
-    if (err instanceof SdkAuthError) {
-      deps.eventsRepo.insert({
-        taskRunId,
-        sessionId: task.sessionId,
-        traceId: null,
-        spanId: null,
-        kind: "sdk_auth_error",
-        payload: { error: err.message },
-      });
-      throw err;
-    }
-    error = (err as Error).message;
-    stopReason = "error";
-  } finally {
-    sandboxWrapper?.cleanup();
-  }
+	try {
+		await invokeWithAutoRefresh(
+			AUTH_RETRY_TOKEN,
+			async () => {
+				await runStreamOnce();
+			},
+			{
+				runSetupToken: deps.authRefresh?.runSetupToken ?? spawnClaudeSetupToken,
+				reloadToken: deps.authRefresh?.reloadToken ?? (() => AUTH_RETRY_TOKEN),
+			},
+		);
+	} catch (err) {
+		if (err instanceof SdkRateLimitError || err instanceof SdkNetworkError) {
+			throw err;
+		}
+		if (err instanceof SdkAuthError) {
+			deps.eventsRepo.insert({
+				taskRunId,
+				sessionId: task.sessionId,
+				traceId: null,
+				spanId: null,
+				kind: "sdk_auth_error",
+				payload: { error: err.message },
+			});
+			throw err;
+		}
+		error = (err as Error).message;
+		stopReason = "error";
+	} finally {
+		sandboxWrapper?.cleanup();
+	}
 
-  return {
-    stopReason,
-    msgsConsumed,
-    totalTurns,
-    finalText: textParts.join("\n").trim(),
-    error,
-  };
+	return {
+		stopReason,
+		msgsConsumed,
+		totalTurns,
+		finalText: textParts.join("\n").trim(),
+		error,
+	};
 }
 
 /**
@@ -561,138 +595,156 @@ async function runAgentWithLedger(
  * stopReason e msgsConsumed são agregados ao longo de todos os stages.
  */
 async function runWithReviewPipeline(
-  deps: RunnerDeps,
-  task: Task,
-  taskRunId: number,
-  attemptN: number,
-  effectivePrompt: string,
-  workingDirectoryOverride: string | null,
-  agentDef: AgentDefinitionLike | null,
-  memorySnippet: string | null,
+	deps: RunnerDeps,
+	task: Task,
+	taskRunId: number,
+	attemptN: number,
+	effectivePrompt: string,
+	workingDirectoryOverride: string | null,
+	agentDef: AgentDefinitionLike | null,
+	memorySnippet: string | null,
 ): Promise<AgentRunResult> {
-  if (deps.review === undefined) {
-    throw new Error("runWithReviewPipeline called without review deps");
-  }
-  let msgsConsumed = 0;
-  let totalStageRuns = 0;
+	if (deps.review === undefined) {
+		throw new Error("runWithReviewPipeline called without review deps");
+	}
+	let msgsConsumed = 0;
+	let totalStageRuns = 0;
 
-  const stageRunner: import("@clawde/review").StageRunner = async (inv) => {
-    const parts: string[] = [];
-    // T-059: prompt do user contém apenas inv.prompt (sem systemPrompt
-    // concatenado). System prompt do role vai pra appendSystemPrompt via
-    // composeAppendSystemPrompt.rolePrompt — separação semântica entre
-    // instrução curada (system) e conteúdo da iteração (user).
-    const stageWorkingDir = workingDirectoryOverride ?? task.workingDir ?? "/no-workspace";
-    const streamOpts: {
-      prompt: string;
-      sessionId?: string;
-      workingDirectory?: string;
-      appendSystemPrompt?: string;
-      allowedTools?: ReadonlyArray<string>;
-      disallowedTools?: ReadonlyArray<string>;
-      maxTurns?: number;
-    } = {
-      prompt: inv.prompt,
-    };
-    if (agentDef?.frontmatter?.maxTurns !== undefined) {
-      streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
-    }
-    if (agentDef?.frontmatter?.allowedTools?.length) {
-      streamOpts.allowedTools = agentDef.frontmatter.allowedTools;
-    }
-    if (agentDef?.frontmatter?.disallowedTools?.length) {
-      streamOpts.disallowedTools = agentDef.frontmatter.disallowedTools;
-    }
-    // T-058: deriva sessionId fresh por stage. Cada role roda em contexto
-    // próprio (não compartilhado com task.sessionId nem entre stages), garantindo
-    // que reviewers não vejam contexto do implementer e vice-versa. Inclui
-    // attemptN pra que retries também ganhem sessões novas.
-    streamOpts.sessionId = deriveSessionId({
-      agent: inv.role,
-      workingDir: stageWorkingDir,
-      intent: `task-${task.id}-${inv.role}-attempt-${attemptN}`,
-    });
-    if (workingDirectoryOverride !== null) {
-      streamOpts.workingDirectory = workingDirectoryOverride;
-    } else if (task.workingDir !== null) {
-      streamOpts.workingDirectory = task.workingDir;
-    }
-    // T-054 + T-055 + T-059: appendSystemPrompt compõe rolePrompt (do stage),
-    // EXTERNAL_INPUT_SYSTEM_PROMPT (quando source externa) e prior_context
-    // (memory) sem sobrescrever uns aos outros.
-    const appendSystemReview = composeAppendSystemPrompt({
-      rolePrompt: inv.systemPrompt,
-      externalInputSafety: isExternalSource(task.source),
-      ...(memorySnippet !== null ? { priorContext: memorySnippet } : {}),
-    });
-    if (appendSystemReview !== undefined) {
-      streamOpts.appendSystemPrompt = appendSystemReview;
-    }
-    for await (const msg of deps.agentClient.stream(streamOpts)) {
-      msgsConsumed += 1;
-      deps.quotaTracker.recordMessage(taskRunId);
-      if (msg.role === "assistant") {
-        const textBlocks = msg.blocks.filter((b) => b.type === "text");
-        for (const b of textBlocks) {
-          if (b.type === "text") parts.push(b.text);
-        }
-      }
-    }
-    totalStageRuns += 1;
-    return parts.join("\n").trim();
-  };
+	const stageRunner: import("@clawde/review").StageRunner = async (inv) => {
+		const parts: string[] = [];
+		// T-059: prompt do user contém apenas inv.prompt (sem systemPrompt
+		// concatenado). System prompt do role vai pra appendSystemPrompt via
+		// composeAppendSystemPrompt.rolePrompt — separação semântica entre
+		// instrução curada (system) e conteúdo da iteração (user).
+		const stageWorkingDir =
+			workingDirectoryOverride ?? task.workingDir ?? "/no-workspace";
+		const streamOpts: {
+			prompt: string;
+			sessionId?: string;
+			workingDirectory?: string;
+			appendSystemPrompt?: string;
+			allowedTools?: ReadonlyArray<string>;
+			disallowedTools?: ReadonlyArray<string>;
+			maxTurns?: number;
+		} = {
+			prompt: inv.prompt,
+		};
+		if (agentDef?.frontmatter?.maxTurns !== undefined) {
+			streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
+		}
+		if (inv.role === "implementer") {
+			// Implementer uses the task agent's declared tools.
+			if (agentDef?.frontmatter?.allowedTools?.length) {
+				streamOpts.allowedTools = agentDef.frontmatter.allowedTools;
+			}
+			if (agentDef?.frontmatter?.disallowedTools?.length) {
+				streamOpts.disallowedTools = agentDef.frontmatter.disallowedTools;
+			}
+		} else {
+			// Reviewer stages operate on inline text — they only need read-only
+			// file tools to cross-check output. No Bash/Edit/Write/WebFetch.
+			streamOpts.allowedTools = ["Read", "Grep", "Glob"];
+			streamOpts.disallowedTools = ["Bash", "Edit", "Write", "WebFetch", "WebSearch"];
+		}
+		// T-058: reviewer stages run in fresh (no sessionId) contexts so they
+		// cannot accidentally resume a prior session that already has the
+		// implementer's output in context. Only the implementer stage gets a
+		// derived sessionId to ensure consistent context across retries.
+		if (inv.role === "implementer") {
+			streamOpts.sessionId = deriveSessionId({
+				agent: inv.role,
+				workingDir: stageWorkingDir,
+				intent: `task-${task.id}-${inv.role}-attempt-${attemptN}`,
+			});
+		}
+		if (workingDirectoryOverride !== null) {
+			streamOpts.workingDirectory = workingDirectoryOverride;
+		} else if (task.workingDir !== null) {
+			streamOpts.workingDirectory = task.workingDir;
+		}
+		// T-054 + T-055 + T-059: appendSystemPrompt compõe rolePrompt (do stage),
+		// EXTERNAL_INPUT_SYSTEM_PROMPT (quando source externa) e prior_context
+		// (memory) sem sobrescrever uns aos outros.
+		const appendSystemReview = composeAppendSystemPrompt({
+			rolePrompt: inv.systemPrompt,
+			externalInputSafety: isExternalSource(task.source),
+			...(memorySnippet !== null ? { priorContext: memorySnippet } : {}),
+		});
+		if (appendSystemReview !== undefined) {
+			streamOpts.appendSystemPrompt = appendSystemReview;
+		}
+		for await (const msg of deps.agentClient.stream(streamOpts)) {
+			msgsConsumed += 1;
+			deps.quotaTracker.recordMessage(taskRunId);
+			if (msg.role === "assistant") {
+				const textBlocks = msg.blocks.filter((b) => b.type === "text");
+				for (const b of textBlocks) {
+					if (b.type === "text") parts.push(b.text);
+				}
+			}
+		}
+		totalStageRuns += 1;
+		return parts.join("\n").trim();
+	};
 
-  try {
-    const result = await deps.review.run(effectivePrompt, deps.review.config, {
-      runner: stageRunner,
-      onStage: (s) => {
-        const stageEvent =
-          s.role === "implementer"
-            ? "review.implementer.end"
-            : s.role === "spec-reviewer"
-              ? "review.spec.verdict"
-              : "review.quality.verdict";
-        deps.eventsRepo.insert({
-          taskRunId,
-          sessionId: task.sessionId,
-          traceId: null,
-          spanId: null,
-          kind: stageEvent,
-          payload: {
-            attempt_n: s.attemptN,
-            ...(s.verdict !== undefined && { verdict: s.verdict }),
-          },
-        });
-      },
-    });
+	try {
+		const result = await deps.review.run(effectivePrompt, deps.review.config, {
+			runner: stageRunner,
+			onStage: (s) => {
+				const stageEvent =
+					s.role === "implementer"
+						? "review.implementer.end"
+						: s.role === "spec-reviewer"
+							? "review.spec.verdict"
+							: "review.quality.verdict";
+				deps.eventsRepo.insert({
+					taskRunId,
+					sessionId: task.sessionId,
+					traceId: null,
+					spanId: null,
+					kind: stageEvent,
+					payload: {
+						attempt_n: s.attemptN,
+						...(s.verdict !== undefined && { verdict: s.verdict }),
+						output_tail: s.output.slice(-200),
+					},
+				});
+			},
+		});
 
-    deps.eventsRepo.insert({
-      taskRunId,
-      sessionId: task.sessionId,
-      traceId: null,
-      spanId: null,
-      kind: result.status === "approved" ? "review.pipeline.complete" : "review.pipeline.exhausted",
-      payload: {
-        rounds: result.totalRoundsRun,
-        status: result.status,
-        msgs_consumed: msgsConsumed,
-      },
-    });
+		deps.eventsRepo.insert({
+			taskRunId,
+			sessionId: task.sessionId,
+			traceId: null,
+			spanId: null,
+			kind:
+				result.status === "approved"
+					? "review.pipeline.complete"
+					: "review.pipeline.exhausted",
+			payload: {
+				rounds: result.totalRoundsRun,
+				status: result.status,
+				msgs_consumed: msgsConsumed,
+			},
+		});
 
-    return {
-      stopReason: result.status === "approved" ? "completed" : "max_turns",
-      msgsConsumed,
-      totalTurns: totalStageRuns,
-      finalText: result.finalOutput ?? "",
-      error: result.status === "approved" ? null : "review pipeline exhausted retries",
-    };
-  } catch (err) {
-    return {
-      stopReason: "error",
-      msgsConsumed,
-      totalTurns: totalStageRuns,
-      finalText: "",
-      error: (err as Error).message,
-    };
-  }
+		return {
+			stopReason: result.status === "approved" ? "completed" : "max_turns",
+			msgsConsumed,
+			totalTurns: totalStageRuns,
+			finalText: result.finalOutput ?? "",
+			error:
+				result.status === "approved"
+					? null
+					: "review pipeline exhausted retries",
+		};
+	} catch (err) {
+		return {
+			stopReason: "error",
+			msgsConsumed,
+			totalTurns: totalStageRuns,
+			finalText: "",
+			error: (err as Error).message,
+		};
+	}
 }

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -31,6 +31,11 @@ import type { QuotaTracker } from "@clawde/quota";
 import type { PipelineConfig, runReviewPipeline as runReviewPipelineFn } from "@clawde/review";
 import { composeAppendSystemPrompt } from "@clawde/sanitize";
 import {
+  isBwrapAvailable,
+  makeSandboxedClaudeWrapper,
+  type SandboxedWrapper,
+} from "@clawde/sandbox";
+import {
   type AgentClient,
   type AgentRunResult,
   SdkAuthError,
@@ -400,13 +405,33 @@ async function runAgentWithLedger(
     allowedTools?: ReadonlyArray<string>;
     disallowedTools?: ReadonlyArray<string>;
     maxTurns?: number;
+    claudeExecutablePath?: string;
   } = {
     prompt: effectivePrompt,
   };
   const allowedTools = agentDef?.frontmatter?.allowedTools ?? [];
   const disallowedTools = new Set(agentDef?.frontmatter?.disallowedTools ?? []);
-  if ((agentDef?.sandbox?.level ?? 1) >= 2) {
+  const sandboxLevel = agentDef?.sandbox?.level ?? 1;
+  if (sandboxLevel >= 2) {
     disallowedTools.add("Bash");
+  }
+
+  // OS-level filesystem sandbox for level >= 2 agents via bwrap.
+  let sandboxWrapper: SandboxedWrapper | null = null;
+  if (sandboxLevel >= 2 && isBwrapAvailable()) {
+    try {
+      sandboxWrapper = makeSandboxedClaudeWrapper(
+        task.agent,
+        agentDef?.sandbox?.read_only_mounts ?? [],
+        process.env as Record<string, string | undefined>,
+      );
+      streamOpts.claudeExecutablePath = sandboxWrapper.wrapperPath;
+    } catch (err) {
+      deps.logger.warn("bwrap wrapper creation failed, running unsandboxed", {
+        agent: task.agent,
+        error: (err as Error).message,
+      });
+    }
   }
   if (allowedTools.length > 0) streamOpts.allowedTools = allowedTools;
   if (disallowedTools.size > 0) streamOpts.disallowedTools = [...disallowedTools];
@@ -505,6 +530,8 @@ async function runAgentWithLedger(
     }
     error = (err as Error).message;
     stopReason = "error";
+  } finally {
+    sandboxWrapper?.cleanup();
   }
 
   return {

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -439,16 +439,27 @@ async function runAgentWithLedger(
     streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
   }
 
+  // For level < 2 agents (no bwrap), sandbox.toml uses "/workspace" as a
+  // placeholder for the ephemeral worktree. Without bwrap there is no filesystem
+  // mapping, so resolve "/workspace" to the actual working directory (issue #51).
+  const rawAllowedWrites = agentDef?.sandbox?.allowed_writes ?? [];
+  const effectiveAllowedWrites =
+    sandboxLevel < 2 && workingDirectoryOverride !== null
+      ? rawAllowedWrites.map((w) => (w === "/workspace" ? workingDirectoryOverride : w))
+      : rawAllowedWrites;
+
   const preToolHandler = makePreToolUseHandler(() => {}, {
     allowedTools,
     sandbox: {
       level: agentDef?.sandbox?.level ?? 1,
-      allowed_writes: agentDef?.sandbox?.allowed_writes ?? [],
+      allowed_writes: effectiveAllowedWrites,
       // Propaga allowed_reads SOMENTE quando definido na config; senão deixa
       // undefined (comportamento legacy permissivo) — `exactOptionalPropertyTypes`.
       ...(agentDef?.sandbox?.allowed_reads !== undefined
         ? { allowed_reads: agentDef.sandbox.allowed_reads }
         : {}),
+      // cwd enables relative-path resolution in write/read checks (issue #51).
+      ...(workingDirectoryOverride !== null ? { cwd: workingDirectoryOverride } : {}),
     },
   });
   if (task.sessionId !== null) streamOpts.sessionId = task.sessionId;

--- a/src/worker/telegram-reply.ts
+++ b/src/worker/telegram-reply.ts
@@ -1,0 +1,66 @@
+import type { Task } from "@clawde/domain/task";
+import type { Logger } from "@clawde/log";
+import type { AgentRunResult } from "@clawde/sdk";
+
+const MAX_TELEGRAM_LEN = 4096;
+
+function readBotToken(): string | null {
+  const env = process.env as Record<string, string | undefined>;
+  return (
+    env["CLAWDE_TELEGRAM_BOT_TOKEN"] ??
+    env["clawde-telegram-bot-token"] ??
+    null
+  );
+}
+
+export async function sendTelegramReply(
+  task: Task,
+  agentResult: AgentRunResult,
+  logger: Logger,
+): Promise<void> {
+  if (task.source !== "telegram") return;
+
+  const token = readBotToken();
+  if (token === null) {
+    logger.warn("telegram reply skipped: no bot token", { taskId: task.id });
+    return;
+  }
+
+  const chatId = task.sourceMetadata["chat_id"];
+  if (typeof chatId !== "number") {
+    logger.warn("telegram reply skipped: no chat_id in metadata", { taskId: task.id });
+    return;
+  }
+
+  const text = agentResult.finalText.trim();
+  if (text.length === 0) {
+    logger.warn("telegram reply skipped: empty result", { taskId: task.id });
+    return;
+  }
+
+  const truncated =
+    text.length > MAX_TELEGRAM_LEN ? text.slice(0, MAX_TELEGRAM_LEN - 3) + "..." : text;
+
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: truncated }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      logger.warn("telegram reply failed", {
+        taskId: task.id,
+        status: response.status,
+        body,
+      });
+    } else {
+      logger.info("telegram reply sent", { taskId: task.id, chat_id: chatId });
+    }
+  } catch (err) {
+    logger.warn("telegram reply error", {
+      taskId: task.id,
+      error: (err as Error).message,
+    });
+  }
+}

--- a/src/worker/workspace.ts
+++ b/src/worker/workspace.ts
@@ -35,6 +35,8 @@ export interface AgentDefinitionLike {
     readonly level: 1 | 2 | 3;
     readonly allowed_writes: ReadonlyArray<string>;
     readonly allowed_reads?: ReadonlyArray<string> | undefined;
+    readonly read_only_mounts?: ReadonlyArray<string>;
+    readonly network?: string;
   };
 }
 


### PR DESCRIPTION
## Fixes #59

main.ts nunca instanciava deps.review, entao review_required=true no clawde.toml nao tinha efeito. runner.ts ja tinha a implementacao completa do pipeline gateada em deps.review !== undefined.

## Mudancas

- Import runReviewPipeline de @clawde/review
- Construir reviewDeps de config.review quando review_required=true, mapeando chaves snake_case do config para camelCase do PipelineConfig
- Usar spread (...) para satisfazer exactOptionalPropertyTypes (nao e possivel passar review: undefined para optional property)

## Test plan

- [ ] bun run tsc --noEmit sem erros
- [ ] clawde.toml com review_required=true + stages + max_retries_per_stage
- [ ] Worker restart: journalctl mostra 'worker bootstrap state' sem erro
- [ ] Task enfileirada: eventos review.implementer.end, review.spec.verdict, review.quality.verdict aparecem na DB