### PR TITLE
fix(worker): headless write bypass gating for issue #58

### DIFF
--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -117,6 +117,9 @@ export class RealAgentClient implements AgentClient {
       } else if (this.defaults.pathToClaudeCodeExecutable !== undefined) {
         queryOptions.pathToClaudeCodeExecutable = this.defaults.pathToClaudeCodeExecutable;
       }
+      if (options.allowDangerouslySkipPermissions !== undefined) {
+        queryOptions.allowDangerouslySkipPermissions = options.allowDangerouslySkipPermissions;
+      }
       if (options.resumeSessionId !== undefined)
         queryOptions.resumeSessionId = options.resumeSessionId;
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -85,6 +85,7 @@ export interface RunAgentOptions {
   readonly appendSystemPrompt?: string;
   readonly workingDirectory?: string;
   readonly pathToClaudeCodeExecutable?: string;
+  readonly allowDangerouslySkipPermissions?: boolean;
   readonly bare?: boolean;
 }
 

--- a/src/worker/runner.ts
+++ b/src/worker/runner.ts
@@ -406,6 +406,7 @@ async function runAgentWithLedger(
     disallowedTools?: ReadonlyArray<string>;
     maxTurns?: number;
     pathToClaudeCodeExecutable?: string;
+    allowDangerouslySkipPermissions?: boolean;
   } = {
     prompt: effectivePrompt,
   };
@@ -437,6 +438,12 @@ async function runAgentWithLedger(
   if (disallowedTools.size > 0) streamOpts.disallowedTools = [...disallowedTools];
   if (agentDef?.frontmatter?.maxTurns !== undefined) {
     streamOpts.maxTurns = agentDef.frontmatter.maxTurns;
+  }
+  const agentHasWriteTools = allowedTools.some(
+    (tool) => tool === "Edit" || tool === "Write" || tool === "Bash",
+  );
+  if (sandboxLevel < 2 && agentHasWriteTools) {
+    streamOpts.allowDangerouslySkipPermissions = true;
   }
 
   const preToolHandler = makePreToolUseHandler(() => {}, {

--- a/tests/integration/worker.test.ts
+++ b/tests/integration/worker.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { EventsRepo } from "@clawde/db/repositories/events";
 import { QuotaLedgerRepo } from "@clawde/db/repositories/quota-ledger";
 import { TaskRunsRepo } from "@clawde/db/repositories/task-runs";
@@ -9,6 +12,19 @@ import { SdkRateLimitError } from "@clawde/sdk";
 import { LeaseManager, type RunnerDeps, processNextPending, processTask } from "@clawde/worker";
 import { type TestDb, makeTestDb } from "../helpers/db.ts";
 import { MockAgentClient, assistantText } from "../mocks/sdk-mock.ts";
+
+class PermissionAwareAgentClient extends MockAgentClient {
+  override async *stream(options: import("@clawde/sdk").RunAgentOptions) {
+    this.invocations.push(options);
+    if (
+      options.workingDirectory !== undefined &&
+      options.allowDangerouslySkipPermissions === true
+    ) {
+      writeFileSync(join(options.workingDirectory, "created-by-agent.txt"), "ok");
+    }
+    yield assistantText("write completed");
+  }
+}
 
 describe("worker/runner end-to-end (com SDK mocked)", () => {
   let testDb: TestDb;
@@ -296,5 +312,115 @@ describe("worker/runner end-to-end (com SDK mocked)", () => {
     expect(second.run.status).toBe("pending");
     expect(second.run.notBefore).not.toBeNull();
     expect(deps.eventsRepo.queryByKind("task_deferred").length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("write-capable L1 agent recebe bypass e arquivo é criado no workspace", async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), "clawde-issue-58-"));
+    const client = new PermissionAwareAgentClient();
+    deps = {
+      ...deps,
+      agentClient: client,
+      resolveAgentDefinition: async () => ({
+        frontmatter: {
+          allowedTools: ["Read", "Write"],
+        },
+        sandbox: {
+          level: 1,
+          allowed_writes: ["/workspace"],
+        },
+      }),
+    };
+    const task = deps.tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "create file",
+      agent: "implementer",
+      sessionId: null,
+      workingDir,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+
+    try {
+      const result = await processTask(deps, task);
+      expect(result.run.status).toBe("succeeded");
+      expect(client.invocations[0]?.allowDangerouslySkipPermissions).toBeTrue();
+      expect(existsSync(join(workingDir, "created-by-agent.txt"))).toBeTrue();
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
+  });
+
+  test("sandboxLevel>=2 não recebe bypass mesmo com Write em allowedTools", async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), "clawde-issue-58-l2-"));
+    const task = deps.tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "no bypass on level2",
+      agent: "implementer",
+      sessionId: null,
+      workingDir,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+    mockClient.enqueueResponse({ messages: [assistantText("ok")] });
+    deps = {
+      ...deps,
+      resolveAgentDefinition: async () => ({
+        frontmatter: {
+          allowedTools: ["Read", "Write"],
+        },
+        sandbox: {
+          level: 2,
+          allowed_writes: ["/workspace"],
+        },
+      }),
+    };
+
+    try {
+      const result = await processTask(deps, task);
+      expect(result.run.status).toBe("succeeded");
+      expect(mockClient.invocations[0]?.allowDangerouslySkipPermissions).toBeUndefined();
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
+  });
+
+  test("agente sem Edit/Write/Bash não recebe bypass", async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), "clawde-issue-58-readonly-"));
+    const task = deps.tasksRepo.insert({
+      priority: "NORMAL",
+      prompt: "readonly tools",
+      agent: "researcher",
+      sessionId: null,
+      workingDir,
+      dependsOn: [],
+      source: "cli",
+      sourceMetadata: {},
+      dedupKey: null,
+    });
+    mockClient.enqueueResponse({ messages: [assistantText("ok")] });
+    deps = {
+      ...deps,
+      resolveAgentDefinition: async () => ({
+        frontmatter: {
+          allowedTools: ["Read", "Grep", "Glob"],
+        },
+        sandbox: {
+          level: 1,
+          allowed_writes: ["/workspace"],
+        },
+      }),
+    };
+
+    try {
+      const result = await processTask(deps, task);
+      expect(result.run.status).toBe("succeeded");
+      expect(mockClient.invocations[0]?.allowDangerouslySkipPermissions).toBeUndefined();
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Closes #58.

## Scope
S1 only (G3 plan): headless write bypass for worker path, guarded lane.

## What changed
- Adds `allowDangerouslySkipPermissions?: boolean` to `RunAgentOptions`.
- Pass-through in `src/sdk/client.ts` to SDK query options when explicitly provided.
- In `runAgentWithLedger` (`src/worker/runner.ts`), sets bypass **only** when:
  - `sandboxLevel < 2`, and
  - agent `allowedTools` includes `Edit`, `Write`, or `Bash`.
- No bypass for `sandboxLevel >= 2`.
- No bypass for read-only agents.

## Acceptance criteria (S1)
- [x] L1 write-capable agent can create file in workspace.
- [x] `sandboxLevel >= 2` does not receive bypass even with write tool.
- [x] Agent without Edit/Write/Bash does not receive bypass.
- [x] Bypass injection lives in `runAgentWithLedger` only.
- [x] Automated regression-style coverage in integration tests.

## Tests added/updated
- `tests/integration/worker.test.ts`
  - `write-capable L1 agent recebe bypass e arquivo é criado no workspace`
  - `sandboxLevel>=2 não recebe bypass mesmo com Write em allowedTools`
  - `agente sem Edit/Write/Bash não recebe bypass`

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run ci`
- `bun run build:worker`

All green locally.
